### PR TITLE
feat: AI recipe summarization with Korean output

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,12 +16,15 @@
     "prisma:studio": "prisma studio"
   },
   "dependencies": {
+    "@asteasolutions/zod-to-openapi": "^7.3.4",
     "@prisma/client": "^6.5.0",
     "@supabase/ssr": "^0.7.0",
     "@supabase/supabase-js": "^2.49.4",
     "next": "latest",
+    "openai": "^6.32.0",
     "react": "latest",
     "react-dom": "latest",
+    "swagger-ui-dist": "^5.32.0",
     "zod": "^3.23.8"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@asteasolutions/zod-to-openapi':
+        specifier: ^7.3.4
+        version: 7.3.4(zod@3.25.76)
       '@prisma/client':
         specifier: ^6.5.0
         version: 6.19.2(prisma@6.19.2(typescript@5.9.3))(typescript@5.9.3)
@@ -20,12 +23,18 @@ importers:
       next:
         specifier: latest
         version: 16.1.6(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      openai:
+        specifier: ^6.32.0
+        version: 6.32.0(ws@8.19.0)(zod@3.25.76)
       react:
         specifier: latest
         version: 19.2.4
       react-dom:
         specifier: latest
         version: 19.2.4(react@19.2.4)
+      swagger-ui-dist:
+        specifier: ^5.32.0
+        version: 5.32.0
       zod:
         specifier: ^3.23.8
         version: 3.25.76
@@ -68,7 +77,7 @@ importers:
         version: 6.19.2(typescript@5.9.3)
       tailwindcss:
         specifier: ^3.4.17
-        version: 3.4.19
+        version: 3.4.19(yaml@2.8.2)
       typescript:
         specifier: ^5.7.2
         version: 5.9.3
@@ -78,6 +87,11 @@ packages:
   '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
+
+  '@asteasolutions/zod-to-openapi@7.3.4':
+    resolution: {integrity: sha512-/2rThQ5zPi9OzVwes6U7lK1+Yvug0iXu25olp7S0XsYmOqnyMfxH7gdSQjn/+DSOHRg7wnotwGJSyL+fBKdnEA==}
+    peerDependencies:
+      zod: ^3.20.2
 
   '@babel/code-frame@7.29.0':
     resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
@@ -467,6 +481,9 @@ packages:
 
   '@rtsao/scc@1.1.0':
     resolution: {integrity: sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==}
+
+  '@scarf/scarf@1.4.0':
+    resolution: {integrity: sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ==}
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
@@ -1669,6 +1686,21 @@ packages:
   ohash@2.0.11:
     resolution: {integrity: sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==}
 
+  openai@6.32.0:
+    resolution: {integrity: sha512-j3k+BjydAf8yQlcOI7WUQMQTbbF5GEIMAE2iZYCOzwwB3S2pCheaWYp+XZRNAch4jWVc52PMDGRRjutao3lLCg==}
+    hasBin: true
+    peerDependencies:
+      ws: ^8.18.0
+      zod: ^3.25 || ^4.0
+    peerDependenciesMeta:
+      ws:
+        optional: true
+      zod:
+        optional: true
+
+  openapi3-ts@4.5.0:
+    resolution: {integrity: sha512-jaL+HgTq2Gj5jRcfdutgRGLosCy/hT8sQf6VOy+P+g36cZOjI1iukdPnijC+4CmeRzg/jEllJUboEic2FhxhtQ==}
+
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
     engines: {node: '>= 0.8.0'}
@@ -2005,6 +2037,9 @@ packages:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
 
+  swagger-ui-dist@5.32.0:
+    resolution: {integrity: sha512-nKZB0OuDvacB0s/lC2gbge+RigYvGRGpLLMWMFxaTUwfM+CfndVk9Th2IaTinqXiz6Mn26GK2zriCpv6/+5m3Q==}
+
   tailwindcss@3.4.19:
     resolution: {integrity: sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ==}
     engines: {node: '>=14.0.0'}
@@ -2138,6 +2173,11 @@ packages:
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
 
+  yaml@2.8.2:
+    resolution: {integrity: sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==}
+    engines: {node: '>= 14.6'}
+    hasBin: true
+
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
@@ -2154,6 +2194,11 @@ packages:
 snapshots:
 
   '@alloc/quick-lru@5.2.0': {}
+
+  '@asteasolutions/zod-to-openapi@7.3.4(zod@3.25.76)':
+    dependencies:
+      openapi3-ts: 4.5.0
+      zod: 3.25.76
 
   '@babel/code-frame@7.29.0':
     dependencies:
@@ -2531,6 +2576,8 @@ snapshots:
       '@prisma/debug': 6.19.2
 
   '@rtsao/scc@1.1.0': {}
+
+  '@scarf/scarf@1.4.0': {}
 
   '@standard-schema/spec@1.1.0': {}
 
@@ -3904,6 +3951,15 @@ snapshots:
 
   ohash@2.0.11: {}
 
+  openai@6.32.0(ws@8.19.0)(zod@3.25.76):
+    optionalDependencies:
+      ws: 8.19.0
+      zod: 3.25.76
+
+  openapi3-ts@4.5.0:
+    dependencies:
+      yaml: 2.8.2
+
   optionator@0.9.4:
     dependencies:
       deep-is: 0.1.4
@@ -3971,12 +4027,13 @@ snapshots:
       camelcase-css: 2.0.1
       postcss: 8.5.8
 
-  postcss-load-config@6.0.1(jiti@1.21.7)(postcss@8.5.8):
+  postcss-load-config@6.0.1(jiti@1.21.7)(postcss@8.5.8)(yaml@2.8.2):
     dependencies:
       lilconfig: 3.1.3
     optionalDependencies:
       jiti: 1.21.7
       postcss: 8.5.8
+      yaml: 2.8.2
 
   postcss-nested@6.2.0(postcss@8.5.8):
     dependencies:
@@ -4295,7 +4352,11 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
-  tailwindcss@3.4.19:
+  swagger-ui-dist@5.32.0:
+    dependencies:
+      '@scarf/scarf': 1.4.0
+
+  tailwindcss@3.4.19(yaml@2.8.2):
     dependencies:
       '@alloc/quick-lru': 5.2.0
       arg: 5.0.2
@@ -4314,7 +4375,7 @@ snapshots:
       postcss: 8.5.8
       postcss-import: 15.1.0(postcss@8.5.8)
       postcss-js: 4.1.0(postcss@8.5.8)
-      postcss-load-config: 6.0.1(jiti@1.21.7)(postcss@8.5.8)
+      postcss-load-config: 6.0.1(jiti@1.21.7)(postcss@8.5.8)(yaml@2.8.2)
       postcss-nested: 6.2.0(postcss@8.5.8)
       postcss-selector-parser: 6.1.2
       resolve: 1.22.11
@@ -4502,6 +4563,8 @@ snapshots:
   ws@8.19.0: {}
 
   yallist@3.1.1: {}
+
+  yaml@2.8.2: {}
 
   yocto-queue@0.1.0: {}
 

--- a/src/apis/recipes.ts
+++ b/src/apis/recipes.ts
@@ -1,4 +1,5 @@
 import type {
+  ApiErrorResponse,
   CreateRecipeRequest,
   DeleteRecipeResponse,
   ListRecipesRequest,
@@ -8,6 +9,15 @@ import type {
   SummarizeRecipeResponse,
   UpdateRecipeRequest
 } from "@/src/apis/@types/recipes";
+
+async function toErrorMessage(response: Response, fallbackMessage: string) {
+  try {
+    const error = (await response.json()) as ApiErrorResponse;
+    return error.message || fallbackMessage;
+  } catch {
+    return fallbackMessage;
+  }
+}
 
 function toQueryString(query: ListRecipesRequest) {
   const params = new URLSearchParams();
@@ -36,7 +46,7 @@ export async function summarizeRecipe(payload: SummarizeRecipeRequest) {
   });
 
   if (!response.ok) {
-    throw new Error("Failed to summarize recipe.");
+    throw new Error(await toErrorMessage(response, "Failed to summarize recipe."));
   }
 
   return (await response.json()) as SummarizeRecipeResponse;
@@ -50,7 +60,7 @@ export async function createRecipe(payload: CreateRecipeRequest) {
   });
 
   if (!response.ok) {
-    throw new Error("Failed to create recipe.");
+    throw new Error(await toErrorMessage(response, "Failed to create recipe."));
   }
 
   return (await response.json()) as RecipeDto;
@@ -60,7 +70,7 @@ export async function listRecipes(query: ListRecipesRequest = {}) {
   const response = await fetch(`/api/recipes${toQueryString(query)}`);
 
   if (!response.ok) {
-    throw new Error("Failed to load recipes.");
+    throw new Error(await toErrorMessage(response, "Failed to load recipes."));
   }
 
   return (await response.json()) as ListRecipesResponse;
@@ -70,7 +80,7 @@ export async function getRecipeById(id: string) {
   const response = await fetch(`/api/recipes/${id}`);
 
   if (!response.ok) {
-    throw new Error("Failed to load recipe.");
+    throw new Error(await toErrorMessage(response, "Failed to load recipe."));
   }
 
   return (await response.json()) as RecipeDto;
@@ -84,7 +94,7 @@ export async function updateRecipe(id: string, payload: UpdateRecipeRequest) {
   });
 
   if (!response.ok) {
-    throw new Error("Failed to update recipe.");
+    throw new Error(await toErrorMessage(response, "Failed to update recipe."));
   }
 
   return (await response.json()) as RecipeDto;
@@ -96,7 +106,7 @@ export async function deleteRecipe(id: string) {
   });
 
   if (!response.ok) {
-    throw new Error("Failed to delete recipe.");
+    throw new Error(await toErrorMessage(response, "Failed to delete recipe."));
   }
 
   return (await response.json()) as DeleteRecipeResponse;

--- a/src/app/api-docs/assets/[asset]/route.ts
+++ b/src/app/api-docs/assets/[asset]/route.ts
@@ -1,0 +1,44 @@
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+
+import { NextResponse } from "next/server";
+
+import { ApiError, toErrorResponse } from "@/src/lib/utils/api-error";
+
+const ASSET_TYPES = {
+  "swagger-ui-bundle.js": "application/javascript; charset=utf-8",
+  "swagger-ui-standalone-preset.js": "application/javascript; charset=utf-8"
+} as const;
+
+type AssetName = keyof typeof ASSET_TYPES;
+
+function isAssetName(value: string): value is AssetName {
+  return value in ASSET_TYPES;
+}
+
+export async function GET(
+  _request: Request,
+  context: { params: Promise<{ asset: string }> }
+) {
+  try {
+    const { asset } = await context.params;
+
+    if (!isAssetName(asset)) {
+      throw new ApiError("NOT_FOUND", "Asset not found", 404);
+    }
+
+    const filePath = path.join(process.cwd(), "node_modules", "swagger-ui-dist", asset);
+    const body = await readFile(filePath, "utf8");
+
+    return new NextResponse(body, {
+      status: 200,
+      headers: {
+        "Content-Type": ASSET_TYPES[asset],
+        "Cache-Control": "public, max-age=3600"
+      }
+    });
+  } catch (error) {
+    const normalized = toErrorResponse(error);
+    return NextResponse.json(normalized.body, { status: normalized.status });
+  }
+}

--- a/src/app/api-docs/layout.tsx
+++ b/src/app/api-docs/layout.tsx
@@ -1,0 +1,7 @@
+import "./swagger-ui.css";
+
+import type { ReactNode } from "react";
+
+export default function ApiDocsLayout({ children }: { children: ReactNode }) {
+  return children;
+}

--- a/src/app/api-docs/page.tsx
+++ b/src/app/api-docs/page.tsx
@@ -8,19 +8,14 @@ export default function ApiDocsPage() {
         OpenAPI source: <code>/api/openapi</code>
       </p>
 
-      <link
-        rel="stylesheet"
-        href="https://unpkg.com/swagger-ui-dist@5/swagger-ui.css"
-      />
-
       <div id="swagger-ui" className="rounded-lg border border-gray-200" />
 
       <Script
-        src="https://unpkg.com/swagger-ui-dist@5/swagger-ui-bundle.js"
+        src="/api-docs/assets/swagger-ui-bundle.js"
         strategy="afterInteractive"
       />
       <Script
-        src="https://unpkg.com/swagger-ui-dist@5/swagger-ui-standalone-preset.js"
+        src="/api-docs/assets/swagger-ui-standalone-preset.js"
         strategy="afterInteractive"
       />
       <Script id="swagger-ui-init" strategy="afterInteractive">{`

--- a/src/app/api-docs/swagger-ui.css
+++ b/src/app/api-docs/swagger-ui.css
@@ -1,0 +1,1 @@
+@import "swagger-ui-dist/swagger-ui.css";

--- a/src/app/api/recipes/summarize/route.ts
+++ b/src/app/api/recipes/summarize/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 
 import { summarizeRecipeSchema } from "@/src/apps/recipes/recipes.schemas";
 import { requireUserId } from "@/src/lib/auth/require-user-id";
-import { inferSourceType } from "@/src/lib/server/recipes/recipes.utils";
+import { summarizeRecipeFromUrl } from "@/src/lib/server/recipes/recipes.summarizer";
 import { toErrorResponse } from "@/src/lib/utils/api-error";
 
 export async function POST(request: NextRequest) {
@@ -10,19 +10,8 @@ export async function POST(request: NextRequest) {
     await requireUserId();
     const json = await request.json();
     const input = summarizeRecipeSchema.parse(json);
-    const sourceType = inferSourceType(input.sourceUrl);
-
-    // TODO: Replace with OpenAI summarize call.
-    return NextResponse.json(
-      {
-        sourceType,
-        titleDraft: "Untitled recipe draft",
-        ingredientsDraft: "- ingredient 1\n- ingredient 2",
-        stepsDraft: "1. Step one\n2. Step two",
-        confidence: 0.35
-      },
-      { status: 200 }
-    );
+    const draft = await summarizeRecipeFromUrl(input);
+    return NextResponse.json(draft, { status: 200 });
   } catch (error) {
     const normalized = toErrorResponse(error);
     return NextResponse.json(normalized.body, { status: normalized.status });

--- a/src/apps/recipes/recipes-home.container.tsx
+++ b/src/apps/recipes/recipes-home.container.tsx
@@ -7,6 +7,7 @@ import {
   createRecipe as createRecipeRequest,
   deleteRecipe as deleteRecipeRequest,
   listRecipes as listRecipesRequest,
+  summarizeRecipe as summarizeRecipeRequest,
   updateRecipe as updateRecipeRequest
 } from "@/src/apis/recipes";
 import { useAuth } from "@/src/apps/app/auth.provider";
@@ -133,6 +134,7 @@ export function RecipesHomeContainer() {
   const [addUrl, setAddUrl] = useState("");
   const [urlError, setUrlError] = useState("");
   const [recipesError, setRecipesError] = useState("");
+  const [isGeneratingDraft, setIsGeneratingDraft] = useState(false);
   const [draftErrors, setDraftErrors] = useState<Partial<Record<keyof RecipeDraft, string>>>({});
   const [toastMessage, setToastMessage] = useState("");
   const [draft, setDraft] = useState<RecipeDraft>({
@@ -229,20 +231,26 @@ export function RecipesHomeContainer() {
     setUrlError("");
   };
 
-  const fillAiDraft = (sourceUrl: string) => {
+  const fillAiDraft = (
+    sourceUrl: string,
+    response: {
+      sourceType: SourceType;
+      titleDraft: string;
+      ingredientsDraft: string;
+      stepsDraft: string;
+    }
+  ) => {
     setDraft({
       sourceUrl,
-      sourceType: inferSourceType(sourceUrl),
-      title: "Spicy Tuna Mayo Rice Bowl",
-      ingredientsText:
-        "- 1 can tuna (drained)\n- 2 tbsp Japanese mayo\n- 1 tsp sriracha\n- 1 tsp soy sauce\n- 1 cup cooked rice",
-      stepsText:
-        "1. Mix tuna, mayo, sriracha, and soy sauce.\n2. Add warm rice to a bowl.\n3. Spoon the tuna mixture over the rice.",
+      sourceType: response.sourceType,
+      title: response.titleDraft,
+      ingredientsText: response.ingredientsDraft,
+      stepsText: response.stepsDraft,
       summarySource: "ai"
     });
   };
 
-  const handleGenerate = () => {
+  const handleGenerate = async () => {
     const sourceUrl = addUrl.trim();
 
     if (!sourceUrl) {
@@ -255,33 +263,20 @@ export function RecipesHomeContainer() {
     }
 
     setUrlError("");
+    setIsGeneratingDraft(true);
     setScreen("loading");
 
-    window.setTimeout(() => {
-      if (sourceUrl.includes("fail")) {
-        setScreen("add");
-        setUrlError("AI draft failed. Retry or continue manually.");
-        return;
-      }
-
-      fillAiDraft(sourceUrl);
+    try {
+      const response = await summarizeRecipeRequest({ sourceUrl });
+      fillAiDraft(sourceUrl, response);
       setDraftErrors({});
       setScreen("review");
-    }, 1200);
-  };
-
-  const handleContinueManual = () => {
-    const sourceUrl = addUrl.trim();
-    setDraft({
-      sourceUrl,
-      sourceType: inferSourceType(sourceUrl),
-      title: "",
-      ingredientsText: "",
-      stepsText: "",
-      summarySource: "manual"
-    });
-    setDraftErrors({});
-    setScreen("review");
+    } catch (error) {
+      setScreen("add");
+      setUrlError(error instanceof Error ? error.message : "AI draft failed. Retry or continue manually.");
+    } finally {
+      setIsGeneratingDraft(false);
+    }
   };
 
   const handleSaveDraft = async () => {
@@ -554,7 +549,7 @@ export function RecipesHomeContainer() {
           <Card className="mx-auto max-w-2xl rounded-2xl p-6 md:p-8">
             <div className="space-y-2">
               <h1 className="text-2xl font-semibold tracking-tight">Add recipe</h1>
-              <p className="text-sm text-muted-foreground">Paste a video link to generate a draft or continue manually.</p>
+              <p className="text-sm text-muted-foreground">Paste a video link to generate a draft, then review and edit it before saving.</p>
             </div>
             <div className="mt-6 space-y-4">
               <div className="space-y-2">
@@ -562,14 +557,9 @@ export function RecipesHomeContainer() {
                 <Input className="h-11 rounded-xl" placeholder="https://www.youtube.com/shorts/..." value={addUrl} onChange={(event) => setAddUrl(event.target.value)} />
                 {urlError ? <p className="text-sm text-destructive">{urlError}</p> : null}
               </div>
-              <div className="flex flex-col gap-3 sm:flex-row">
-                <Button className="h-11 flex-1" onClick={handleGenerate} type="button">
-                  Generate with AI
-                </Button>
-                <Button className="h-11 flex-1" variant="outline" onClick={handleContinueManual} type="button">
-                  Continue manually
-                </Button>
-              </div>
+              <Button className="h-11 w-full" onClick={() => void handleGenerate()} type="button" disabled={isGeneratingDraft}>
+                {isGeneratingDraft ? "Generating..." : "Generate with AI"}
+              </Button>
               <Button className="h-11" variant="ghost" onClick={() => setScreen("list")} type="button">
                 Back to list
               </Button>

--- a/src/apps/recipes/recipes.types.ts
+++ b/src/apps/recipes/recipes.types.ts
@@ -16,6 +16,13 @@ export type CreateRecipeInput = z.infer<typeof createRecipeSchema>;
 export type UpdateRecipeInput = z.infer<typeof updateRecipeSchema>;
 export type SummarizeRecipeInput = z.infer<typeof summarizeRecipeSchema>;
 export type ListRecipesQuery = z.infer<typeof listRecipesQuerySchema>;
+export type SummarizedRecipeDraft = {
+  sourceType: SourceType;
+  titleDraft: string;
+  ingredientsDraft: string;
+  stepsDraft: string;
+  confidence?: number;
+};
 
 export type Recipe = {
   id: string;

--- a/src/lib/server/openapi/openapi.spec.ts
+++ b/src/lib/server/openapi/openapi.spec.ts
@@ -1,8 +1,399 @@
+import { extendZodWithOpenApi,OpenApiGeneratorV3, OpenAPIRegistry } from "@asteasolutions/zod-to-openapi";
+import { z } from "zod";
+
+import {
+  createRecipeSchema,
+  listRecipesQuerySchema,
+  sourceTypeSchema,
+  summarizeRecipeSchema,
+  summarySourceSchema,
+  updateRecipeSchema
+} from "@/src/apps/recipes/recipes.schemas";
+import { APP_CONFIG } from "@/src/config/app";
+
+extendZodWithOpenApi(z);
+
+const registry = new OpenAPIRegistry();
+
+const errorResponseSchema = registry.register(
+  "ErrorResponse",
+  z.object({
+    code: z
+      .enum(["UNAUTHORIZED", "FORBIDDEN", "NOT_FOUND", "VALIDATION_ERROR", "INTERNAL_ERROR"])
+      .openapi({ example: "VALIDATION_ERROR" }),
+    message: z.string().openapi({ example: "Invalid request" }),
+    details: z.unknown().optional()
+  })
+);
+
+const healthStatusSchema = registry.register(
+  "HealthStatus",
+  z.object({
+    ok: z.literal(true),
+    service: z.string().openapi({ example: "pantry-clip-api" }),
+    timestamp: z.string().datetime().openapi({ example: "2026-03-12T12:00:00.000Z" }),
+    uptimeSec: z.number().openapi({ example: 123 })
+  })
+);
+
+const sourceTypeOpenApiSchema = sourceTypeSchema.openapi("SourceType");
+const summarySourceOpenApiSchema = summarySourceSchema.openapi("SummarySource");
+
+const recipeSchema = registry.register(
+  "Recipe",
+  z.object({
+    id: z.string().uuid(),
+    userId: z.string().uuid(),
+    sourceUrl: z.string().url(),
+    sourceType: sourceTypeOpenApiSchema,
+    title: z.string().min(1).max(140),
+    ingredientsText: z.string().min(1),
+    stepsText: z.string().min(1),
+    summarySource: summarySourceOpenApiSchema,
+    aiConfidence: z.number().min(0).max(1).nullable(),
+    createdAt: z.string().datetime(),
+    updatedAt: z.string().datetime()
+  })
+);
+
+const summarizeRecipeRequestSchema = summarizeRecipeSchema.openapi("SummarizeRecipeRequest");
+
+const summarizeRecipeResponseSchema = registry.register(
+  "SummarizeRecipeResponse",
+  z.object({
+    sourceType: sourceTypeOpenApiSchema,
+    titleDraft: z.string(),
+    ingredientsDraft: z.string(),
+    stepsDraft: z.string(),
+    confidence: z.number().min(0).max(1).optional()
+  })
+);
+
+const createRecipeRequestSchema = createRecipeSchema.openapi("CreateRecipeRequest");
+const updateRecipeRequestSchema = updateRecipeSchema.openapi("UpdateRecipeRequest", {
+  description: "At least one field must be provided.",
+  minProperties: 1
+});
+
+const listRecipesResponseSchema = registry.register(
+  "ListRecipesResponse",
+  z.object({
+    items: z.array(recipeSchema),
+    nextCursor: z.string().optional()
+  })
+);
+
+const deleteRecipeResponseSchema = registry.register(
+  "DeleteRecipeResponse",
+  z.object({
+    ok: z.literal(true)
+  })
+);
+
+const recipeIdParamsSchema = z.object({
+  id: z.string().uuid().openapi({
+    param: {
+      name: "id",
+      in: "path"
+    },
+    example: "11111111-1111-1111-1111-111111111111"
+  })
+});
+
+const listRecipesQueryOpenApiSchema = z.object({
+  q: z.string().trim().optional().openapi({
+    param: {
+      name: "q",
+      in: "query",
+      description: "Title search query"
+    },
+    example: "pasta"
+  }),
+  cursor: z.string().trim().optional().openapi({
+    param: {
+      name: "cursor",
+      in: "query",
+      description: "Opaque pagination cursor"
+    }
+  }),
+  limit: listRecipesQuerySchema.shape.limit.openapi({
+    param: {
+      name: "limit",
+      in: "query",
+      description: "Page size"
+    },
+    example: 20
+  })
+});
+
+registry.registerPath({
+  method: "get",
+  path: "/api/health",
+  tags: ["Health"],
+  summary: "Health check",
+  responses: {
+    200: {
+      description: "Service health",
+      content: {
+        "application/json": {
+          schema: healthStatusSchema
+        }
+      }
+    }
+  }
+});
+
+registry.registerPath({
+  method: "post",
+  path: "/api/recipes/summarize",
+  tags: ["Recipes"],
+  summary: "Generate an AI recipe draft from source URL",
+  request: {
+    body: {
+      required: true,
+      content: {
+        "application/json": {
+          schema: summarizeRecipeRequestSchema
+        }
+      }
+    }
+  },
+  responses: {
+    200: {
+      description: "Draft generated",
+      content: {
+        "application/json": {
+          schema: summarizeRecipeResponseSchema
+        }
+      }
+    },
+    400: {
+      description: "Validation error",
+      content: {
+        "application/json": {
+          schema: errorResponseSchema
+        }
+      }
+    },
+    401: {
+      description: "Unauthorized",
+      content: {
+        "application/json": {
+          schema: errorResponseSchema
+        }
+      }
+    }
+  }
+});
+
+registry.registerPath({
+  method: "get",
+  path: "/api/recipes",
+  tags: ["Recipes"],
+  summary: "List recipes",
+  request: {
+    query: listRecipesQueryOpenApiSchema
+  },
+  responses: {
+    200: {
+      description: "Paginated recipes",
+      content: {
+        "application/json": {
+          schema: listRecipesResponseSchema
+        }
+      }
+    },
+    400: {
+      description: "Validation error",
+      content: {
+        "application/json": {
+          schema: errorResponseSchema
+        }
+      }
+    },
+    401: {
+      description: "Unauthorized",
+      content: {
+        "application/json": {
+          schema: errorResponseSchema
+        }
+      }
+    }
+  }
+});
+
+registry.registerPath({
+  method: "post",
+  path: "/api/recipes",
+  tags: ["Recipes"],
+  summary: "Create a recipe",
+  request: {
+    body: {
+      required: true,
+      content: {
+        "application/json": {
+          schema: createRecipeRequestSchema
+        }
+      }
+    }
+  },
+  responses: {
+    201: {
+      description: "Created recipe",
+      content: {
+        "application/json": {
+          schema: recipeSchema
+        }
+      }
+    },
+    400: {
+      description: "Validation error",
+      content: {
+        "application/json": {
+          schema: errorResponseSchema
+        }
+      }
+    },
+    401: {
+      description: "Unauthorized",
+      content: {
+        "application/json": {
+          schema: errorResponseSchema
+        }
+      }
+    }
+  }
+});
+
+registry.registerPath({
+  method: "get",
+  path: "/api/recipes/{id}",
+  tags: ["Recipes"],
+  summary: "Get recipe detail",
+  request: {
+    params: recipeIdParamsSchema
+  },
+  responses: {
+    200: {
+      description: "Recipe detail",
+      content: {
+        "application/json": {
+          schema: recipeSchema
+        }
+      }
+    },
+    401: {
+      description: "Unauthorized",
+      content: {
+        "application/json": {
+          schema: errorResponseSchema
+        }
+      }
+    },
+    404: {
+      description: "Not found",
+      content: {
+        "application/json": {
+          schema: errorResponseSchema
+        }
+      }
+    }
+  }
+});
+
+registry.registerPath({
+  method: "patch",
+  path: "/api/recipes/{id}",
+  tags: ["Recipes"],
+  summary: "Update recipe",
+  request: {
+    params: recipeIdParamsSchema,
+    body: {
+      required: true,
+      content: {
+        "application/json": {
+          schema: updateRecipeRequestSchema
+        }
+      }
+    }
+  },
+  responses: {
+    200: {
+      description: "Updated recipe",
+      content: {
+        "application/json": {
+          schema: recipeSchema
+        }
+      }
+    },
+    400: {
+      description: "Validation error",
+      content: {
+        "application/json": {
+          schema: errorResponseSchema
+        }
+      }
+    },
+    401: {
+      description: "Unauthorized",
+      content: {
+        "application/json": {
+          schema: errorResponseSchema
+        }
+      }
+    },
+    404: {
+      description: "Not found",
+      content: {
+        "application/json": {
+          schema: errorResponseSchema
+        }
+      }
+    }
+  }
+});
+
+registry.registerPath({
+  method: "delete",
+  path: "/api/recipes/{id}",
+  tags: ["Recipes"],
+  summary: "Delete recipe",
+  request: {
+    params: recipeIdParamsSchema
+  },
+  responses: {
+    200: {
+      description: "Delete result",
+      content: {
+        "application/json": {
+          schema: deleteRecipeResponseSchema
+        }
+      }
+    },
+    401: {
+      description: "Unauthorized",
+      content: {
+        "application/json": {
+          schema: errorResponseSchema
+        }
+      }
+    },
+    404: {
+      description: "Not found",
+      content: {
+        "application/json": {
+          schema: errorResponseSchema
+        }
+      }
+    }
+  }
+});
+
 export function getOpenApiSpec() {
-  return {
+  return new OpenApiGeneratorV3(registry.definitions).generateDocument({
     openapi: "3.0.3",
     info: {
-      title: "PantryClip API",
+      title: `${APP_CONFIG.appName} API`,
       version: "0.1.0",
       description: "MVP API for PantryClip recipe capture and management"
     },
@@ -12,421 +403,6 @@ export function getOpenApiSpec() {
         description: "Local development"
       }
     ],
-    tags: [
-      { name: "Health" },
-      { name: "Recipes" }
-    ],
-    paths: {
-      "/api/health": {
-        get: {
-          tags: ["Health"],
-          summary: "Health check",
-          responses: {
-            "200": {
-              description: "Service health",
-              content: {
-                "application/json": {
-                  schema: { $ref: "#/components/schemas/HealthStatus" }
-                }
-              }
-            }
-          }
-        }
-      },
-      "/api/recipes/summarize": {
-        post: {
-          tags: ["Recipes"],
-          summary: "Generate an AI recipe draft from source URL",
-          requestBody: {
-            required: true,
-            content: {
-              "application/json": {
-                schema: { $ref: "#/components/schemas/SummarizeRecipeRequest" }
-              }
-            }
-          },
-          responses: {
-            "200": {
-              description: "Draft generated",
-              content: {
-                "application/json": {
-                  schema: { $ref: "#/components/schemas/SummarizeRecipeResponse" }
-                }
-              }
-            },
-            "400": {
-              description: "Validation error",
-              content: {
-                "application/json": {
-                  schema: { $ref: "#/components/schemas/ErrorResponse" }
-                }
-              }
-            },
-            "401": {
-              description: "Unauthorized",
-              content: {
-                "application/json": {
-                  schema: { $ref: "#/components/schemas/ErrorResponse" }
-                }
-              }
-            }
-          }
-        }
-      },
-      "/api/recipes": {
-        get: {
-          tags: ["Recipes"],
-          summary: "List recipes",
-          parameters: [
-            {
-              name: "q",
-              in: "query",
-              required: false,
-              schema: { type: "string" },
-              description: "Title search query"
-            },
-            {
-              name: "cursor",
-              in: "query",
-              required: false,
-              schema: { type: "string" },
-              description: "Opaque pagination cursor"
-            },
-            {
-              name: "limit",
-              in: "query",
-              required: false,
-              schema: { type: "integer", minimum: 1, maximum: 50, default: 20 },
-              description: "Page size"
-            }
-          ],
-          responses: {
-            "200": {
-              description: "Paginated recipes",
-              content: {
-                "application/json": {
-                  schema: { $ref: "#/components/schemas/ListRecipesResponse" }
-                }
-              }
-            },
-            "400": {
-              description: "Validation error",
-              content: {
-                "application/json": {
-                  schema: { $ref: "#/components/schemas/ErrorResponse" }
-                }
-              }
-            },
-            "401": {
-              description: "Unauthorized",
-              content: {
-                "application/json": {
-                  schema: { $ref: "#/components/schemas/ErrorResponse" }
-                }
-              }
-            }
-          }
-        },
-        post: {
-          tags: ["Recipes"],
-          summary: "Create a recipe",
-          requestBody: {
-            required: true,
-            content: {
-              "application/json": {
-                schema: { $ref: "#/components/schemas/CreateRecipeRequest" }
-              }
-            }
-          },
-          responses: {
-            "201": {
-              description: "Created recipe",
-              content: {
-                "application/json": {
-                  schema: { $ref: "#/components/schemas/Recipe" }
-                }
-              }
-            },
-            "400": {
-              description: "Validation error",
-              content: {
-                "application/json": {
-                  schema: { $ref: "#/components/schemas/ErrorResponse" }
-                }
-              }
-            },
-            "401": {
-              description: "Unauthorized",
-              content: {
-                "application/json": {
-                  schema: { $ref: "#/components/schemas/ErrorResponse" }
-                }
-              }
-            }
-          }
-        }
-      },
-      "/api/recipes/{id}": {
-        get: {
-          tags: ["Recipes"],
-          summary: "Get recipe detail",
-          parameters: [
-            {
-              name: "id",
-              in: "path",
-              required: true,
-              schema: { type: "string", format: "uuid" }
-            }
-          ],
-          responses: {
-            "200": {
-              description: "Recipe detail",
-              content: {
-                "application/json": {
-                  schema: { $ref: "#/components/schemas/Recipe" }
-                }
-              }
-            },
-            "401": {
-              description: "Unauthorized",
-              content: {
-                "application/json": {
-                  schema: { $ref: "#/components/schemas/ErrorResponse" }
-                }
-              }
-            },
-            "404": {
-              description: "Not found",
-              content: {
-                "application/json": {
-                  schema: { $ref: "#/components/schemas/ErrorResponse" }
-                }
-              }
-            }
-          }
-        },
-        patch: {
-          tags: ["Recipes"],
-          summary: "Update recipe",
-          parameters: [
-            {
-              name: "id",
-              in: "path",
-              required: true,
-              schema: { type: "string", format: "uuid" }
-            }
-          ],
-          requestBody: {
-            required: true,
-            content: {
-              "application/json": {
-                schema: { $ref: "#/components/schemas/UpdateRecipeRequest" }
-              }
-            }
-          },
-          responses: {
-            "200": {
-              description: "Updated recipe",
-              content: {
-                "application/json": {
-                  schema: { $ref: "#/components/schemas/Recipe" }
-                }
-              }
-            },
-            "400": {
-              description: "Validation error",
-              content: {
-                "application/json": {
-                  schema: { $ref: "#/components/schemas/ErrorResponse" }
-                }
-              }
-            },
-            "401": {
-              description: "Unauthorized",
-              content: {
-                "application/json": {
-                  schema: { $ref: "#/components/schemas/ErrorResponse" }
-                }
-              }
-            },
-            "404": {
-              description: "Not found",
-              content: {
-                "application/json": {
-                  schema: { $ref: "#/components/schemas/ErrorResponse" }
-                }
-              }
-            }
-          }
-        },
-        delete: {
-          tags: ["Recipes"],
-          summary: "Delete recipe",
-          parameters: [
-            {
-              name: "id",
-              in: "path",
-              required: true,
-              schema: { type: "string", format: "uuid" }
-            }
-          ],
-          responses: {
-            "200": {
-              description: "Delete result",
-              content: {
-                "application/json": {
-                  schema: { $ref: "#/components/schemas/DeleteRecipeResponse" }
-                }
-              }
-            },
-            "401": {
-              description: "Unauthorized",
-              content: {
-                "application/json": {
-                  schema: { $ref: "#/components/schemas/ErrorResponse" }
-                }
-              }
-            },
-            "404": {
-              description: "Not found",
-              content: {
-                "application/json": {
-                  schema: { $ref: "#/components/schemas/ErrorResponse" }
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    components: {
-      schemas: {
-        SourceType: {
-          type: "string",
-          enum: ["youtube_shorts", "instagram_reels", "other"]
-        },
-        SummarySource: {
-          type: "string",
-          enum: ["manual", "ai"]
-        },
-        HealthStatus: {
-          type: "object",
-          required: ["ok", "service", "timestamp", "uptimeSec"],
-          properties: {
-            ok: { type: "boolean" },
-            service: { type: "string" },
-            timestamp: { type: "string", format: "date-time" },
-            uptimeSec: { type: "number" }
-          }
-        },
-        ErrorResponse: {
-          type: "object",
-          required: ["code", "message"],
-          properties: {
-            code: { type: "string" },
-            message: { type: "string" },
-            details: {}
-          }
-        },
-        Recipe: {
-          type: "object",
-          required: [
-            "id",
-            "userId",
-            "sourceUrl",
-            "sourceType",
-            "title",
-            "ingredientsText",
-            "stepsText",
-            "summarySource",
-            "aiConfidence",
-            "createdAt",
-            "updatedAt"
-          ],
-          properties: {
-            id: { type: "string", format: "uuid" },
-            userId: { type: "string" },
-            sourceUrl: { type: "string", format: "uri" },
-            sourceType: { $ref: "#/components/schemas/SourceType" },
-            title: { type: "string", minLength: 1, maxLength: 140 },
-            ingredientsText: { type: "string", minLength: 1 },
-            stepsText: { type: "string", minLength: 1 },
-            summarySource: { $ref: "#/components/schemas/SummarySource" },
-            aiConfidence: { type: "number", minimum: 0, maximum: 1, nullable: true },
-            createdAt: { type: "string", format: "date-time" },
-            updatedAt: { type: "string", format: "date-time" }
-          }
-        },
-        SummarizeRecipeRequest: {
-          type: "object",
-          required: ["sourceUrl"],
-          properties: {
-            sourceUrl: { type: "string", format: "uri" }
-          }
-        },
-        SummarizeRecipeResponse: {
-          type: "object",
-          required: ["sourceType", "titleDraft", "ingredientsDraft", "stepsDraft"],
-          properties: {
-            sourceType: { $ref: "#/components/schemas/SourceType" },
-            titleDraft: { type: "string" },
-            ingredientsDraft: { type: "string" },
-            stepsDraft: { type: "string" },
-            confidence: { type: "number", minimum: 0, maximum: 1 }
-          }
-        },
-        CreateRecipeRequest: {
-          type: "object",
-          required: [
-            "sourceUrl",
-            "sourceType",
-            "title",
-            "ingredientsText",
-            "stepsText",
-            "summarySource"
-          ],
-          properties: {
-            sourceUrl: { type: "string", format: "uri" },
-            sourceType: { $ref: "#/components/schemas/SourceType" },
-            title: { type: "string", minLength: 1, maxLength: 140 },
-            ingredientsText: { type: "string", minLength: 1 },
-            stepsText: { type: "string", minLength: 1 },
-            summarySource: { $ref: "#/components/schemas/SummarySource" },
-            aiConfidence: { type: "number", minimum: 0, maximum: 1, nullable: true }
-          }
-        },
-        UpdateRecipeRequest: {
-          type: "object",
-          minProperties: 1,
-          properties: {
-            sourceUrl: { type: "string", format: "uri" },
-            sourceType: { $ref: "#/components/schemas/SourceType" },
-            title: { type: "string", minLength: 1, maxLength: 140 },
-            ingredientsText: { type: "string", minLength: 1 },
-            stepsText: { type: "string", minLength: 1 },
-            summarySource: { $ref: "#/components/schemas/SummarySource" },
-            aiConfidence: { type: "number", minimum: 0, maximum: 1, nullable: true }
-          }
-        },
-        ListRecipesResponse: {
-          type: "object",
-          required: ["items"],
-          properties: {
-            items: {
-              type: "array",
-              items: { $ref: "#/components/schemas/Recipe" }
-            },
-            nextCursor: { type: "string" }
-          }
-        },
-        DeleteRecipeResponse: {
-          type: "object",
-          required: ["ok"],
-          properties: {
-            ok: { type: "boolean", enum: [true] }
-          }
-        }
-      }
-    }
-  };
+    tags: [{ name: "Health" }, { name: "Recipes" }]
+  });
 }

--- a/src/lib/server/recipes/recipes.summarizer.ts
+++ b/src/lib/server/recipes/recipes.summarizer.ts
@@ -4,8 +4,6 @@ import { z } from "zod";
 import type { SummarizedRecipeDraft, SummarizeRecipeInput } from "@/src/apps/recipes/recipes.types";
 import { inferSourceType } from "@/src/lib/server/recipes/recipes.utils";
 
-const client = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
-
 const recipeDraftSchema = z.object({
   title: z.string(),
   ingredients: z.array(z.string()),
@@ -44,6 +42,7 @@ async function fetchPageMeta(url: string): Promise<{ title: string; description:
 export async function summarizeRecipeFromUrl(
   input: SummarizeRecipeInput
 ): Promise<SummarizedRecipeDraft> {
+  const client = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
   const sourceType = inferSourceType(input.sourceUrl);
   const meta = await fetchPageMeta(input.sourceUrl);
 

--- a/src/lib/server/recipes/recipes.summarizer.ts
+++ b/src/lib/server/recipes/recipes.summarizer.ts
@@ -1,0 +1,93 @@
+import OpenAI from "openai";
+import { z } from "zod";
+
+import type { SummarizedRecipeDraft, SummarizeRecipeInput } from "@/src/apps/recipes/recipes.types";
+import { inferSourceType } from "@/src/lib/server/recipes/recipes.utils";
+
+const client = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+
+const recipeDraftSchema = z.object({
+  title: z.string(),
+  ingredients: z.array(z.string()),
+  steps: z.array(z.string()),
+  confidence: z.number().min(0).max(1)
+});
+
+async function fetchPageMeta(url: string): Promise<{ title: string; description: string }> {
+  try {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 5000);
+
+    const response = await fetch(url, {
+      signal: controller.signal,
+      headers: { "User-Agent": "Mozilla/5.0 (compatible; PantryClip/1.0)" }
+    });
+
+    clearTimeout(timeout);
+
+    const html = await response.text();
+
+    const ogTitle = html.match(/<meta[^>]+property=["']og:title["'][^>]+content=["']([^"']+)["']/i)?.[1];
+    const metaTitle = html.match(/<title[^>]*>([^<]+)<\/title>/i)?.[1];
+    const ogDesc = html.match(/<meta[^>]+property=["']og:description["'][^>]+content=["']([^"']+)["']/i)?.[1];
+    const metaDesc = html.match(/<meta[^>]+name=["']description["'][^>]+content=["']([^"']+)["']/i)?.[1];
+
+    return {
+      title: (ogTitle ?? metaTitle ?? "").trim(),
+      description: (ogDesc ?? metaDesc ?? "").trim()
+    };
+  } catch {
+    return { title: "", description: "" };
+  }
+}
+
+export async function summarizeRecipeFromUrl(
+  input: SummarizeRecipeInput
+): Promise<SummarizedRecipeDraft> {
+  const sourceType = inferSourceType(input.sourceUrl);
+  const meta = await fetchPageMeta(input.sourceUrl);
+
+  const contextLines: string[] = [`URL: ${input.sourceUrl}`];
+  if (meta.title) contextLines.push(`제목: ${meta.title}`);
+  if (meta.description) contextLines.push(`설명: ${meta.description}`);
+
+  const prompt = `당신은 요리 레시피 전문가입니다. 아래 동영상 링크 정보를 바탕으로 레시피 초안을 작성해주세요. 모든 내용은 한국어로 작성합니다.
+
+${contextLines.join("\n")}
+
+다음 JSON 형식으로만 응답하세요:
+{
+  "title": "레시피 제목 (간결하게, 최대 40자)",
+  "ingredients": ["재료1", "재료2", ...],
+  "steps": ["1단계 설명", "2단계 설명", ...],
+  "confidence": 0.0~1.0 사이의 숫자 (URL 정보 기반 신뢰도)
+}
+
+규칙:
+- 재료는 개별 항목으로 나열 (각 항목 앞에 "- " 불필요)
+- 조리 단계는 순서대로, 각 단계는 명확하고 구체적으로
+- 동영상 정보가 부족하면 일반적인 해당 요리 레시피를 작성하되 confidence는 낮게 설정
+- 제목은 요리 이름만 (예: "간장 계란밥", "떡볶이")`;
+
+  const completion = await client.chat.completions.create(
+    {
+      model: "gpt-4o-mini",
+      messages: [{ role: "user", content: prompt }],
+      response_format: { type: "json_object" },
+      temperature: 0.3,
+      max_tokens: 1000
+    },
+    { timeout: 15000 }
+  );
+
+  const raw = JSON.parse(completion.choices[0].message.content ?? "{}");
+  const parsed = recipeDraftSchema.parse(raw);
+
+  return {
+    sourceType,
+    titleDraft: parsed.title,
+    ingredientsDraft: parsed.ingredients.map((item) => `- ${item}`).join("\n"),
+    stepsDraft: parsed.steps.map((step, i) => `${i + 1}. ${step}`).join("\n"),
+    confidence: parsed.confidence
+  };
+}


### PR DESCRIPTION
<!-- pr-description:start -->
## Summary
Implements AI-assisted recipe summarization flow with Korean output, expands API/docs infrastructure, and introduces server-side summarization logic and UI integration for drafting AI-generated recipe summaries.

## Changes
- package.json: added dependencies (@asteasolutions/zod-to-openapi, openai, swagger-ui-dist)
- pnpm-lock.yaml: updated to include new dependencies
- src/apis/recipes.ts: added error message extractor; improved error handling messages for summarize/create/list/get/update/delete operations
- src/app/api-docs/assets/[asset]/route.ts: added asset serving for swagger-ui-dist assets
- src/app/api-docs/layout.tsx: added layout wrapper for API docs
- src/app/api-docs/page.tsx: wired Swagger assets to local routes
- src/app/api-docs/swagger-ui.css: added stylesheet
- src/app/api/recipes/summarize/route.ts: switched to using summarizeRecipeFromUrl for AI-generated draft; integrated error handling
- src/apps/recipes/recipes-home.container.tsx: integrated summarizeRecipe flow into UI; added loading state and draft handling; wired draft filling from summarize results
- src/apps/recipes/recipes.types.ts: added SummarizedRecipeDraft type
- src/lib/server/openapi/openapi.spec.ts: expanded OpenAPI schema generation to include summarize recipe request/response types and new Draft structure
- src/lib/server/recipes/recipes.summarizer.ts: added new module to fetch page metadata and generate Korean draft via OpenAI, producing SummarizedRecipeDraft

## Risks
- None identified.

## Testing
- No explicit tests added or executed in this patch.
<!-- pr-description:end -->