### PR TITLE
Add audio transcription fallback for YouTube Shorts summarize jobs

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   },
   "dependencies": {
     "@asteasolutions/zod-to-openapi": "^7.3.4",
+    "@distube/ytdl-core": "^4.16.12",
     "@prisma/client": "^6.5.0",
     "@supabase/ssr": "^0.7.0",
     "@supabase/supabase-js": "^2.49.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@asteasolutions/zod-to-openapi':
         specifier: ^7.3.4
         version: 7.3.4(zod@3.25.76)
+      '@distube/ytdl-core':
+        specifier: ^4.16.12
+        version: 4.16.12
       '@prisma/client':
         specifier: ^6.5.0
         version: 6.19.2(prisma@6.19.2(typescript@5.9.3))(typescript@5.9.3)
@@ -159,6 +162,10 @@ packages:
   '@babel/types@7.29.0':
     resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
     engines: {node: '>=6.9.0'}
+
+  '@distube/ytdl-core@4.16.12':
+    resolution: {integrity: sha512-/NR8Jur1Q4E2oD+DJta7uwWu7SkqdEkhwERt7f4iune70zg7ZlLLTOHs1+jgg3uD2jQjpdk7RGC16FqstG4RsA==}
+    engines: {node: '>=20.18.1'}
 
   '@emnapi/core@1.8.1':
     resolution: {integrity: sha512-AvT9QFpxK0Zd8J0jopedNm+w/2fIzvtPKPjqyw9jwvBaReTTqPBk9Hixaz7KbjimP+QNz605/XnjFcDAL2pqBg==}
@@ -712,6 +719,10 @@ packages:
     resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
     engines: {node: '>=0.4.0'}
     hasBin: true
+
+  agent-base@7.1.4:
+    resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
+    engines: {node: '>= 14'}
 
   ajv@6.14.0:
     resolution: {integrity: sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==}
@@ -1348,6 +1359,20 @@ packages:
   hermes-parser@0.25.1:
     resolution: {integrity: sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==}
 
+  http-cookie-agent@7.0.3:
+    resolution: {integrity: sha512-EeZo7CGhfqPW6R006rJa4QtZZUpBygDa2HZH3DJqsTzTjyRE6foDBVQIv/pjVsxHC8z2GIdbB1Hvn9SRorP3WQ==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      tough-cookie: ^4.0.0 || ^5.0.0 || ^6.0.0
+      undici: ^7.0.0
+    peerDependenciesMeta:
+      undici:
+        optional: true
+
+  https-proxy-agent@7.0.6:
+    resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
+    engines: {node: '>= 14'}
+
   iceberg-js@0.8.1:
     resolution: {integrity: sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA==}
     engines: {node: '>=20.0.0'}
@@ -1566,6 +1591,10 @@ packages:
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
+  m3u8stream@0.8.6:
+    resolution: {integrity: sha512-LZj8kIVf9KCphiHmH7sbFQTVe4tOemb202fWwvJwR9W5ENW/1hxJN6ksAWGhQgSBSa3jyWhnjKU1Fw1GaOdbyA==}
+    engines: {node: '>=12'}
+
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
@@ -1577,6 +1606,10 @@ packages:
   micromatch@4.0.8:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
     engines: {node: '>=8.6'}
+
+  miniget@4.2.3:
+    resolution: {integrity: sha512-SjbDPDICJ1zT+ZvQwK0hUcRY4wxlhhNpHL9nJOB2MEAXRGagTljsO8MEDzQMTFf0Q8g4QNi8P9lEm/g7e+qgzA==}
+    engines: {node: '>=12'}
 
   minimatch@10.2.4:
     resolution: {integrity: sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==}
@@ -1917,6 +1950,10 @@ packages:
     resolution: {integrity: sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==}
     engines: {node: '>= 0.4'}
 
+  sax@1.6.0:
+    resolution: {integrity: sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==}
+    engines: {node: '>=11.0.0'}
+
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
 
@@ -2060,9 +2097,20 @@ packages:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
     engines: {node: '>=12.0.0'}
 
+  tldts-core@6.1.86:
+    resolution: {integrity: sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==}
+
+  tldts@6.1.86:
+    resolution: {integrity: sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==}
+    hasBin: true
+
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
+
+  tough-cookie@5.1.2:
+    resolution: {integrity: sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==}
+    engines: {node: '>=16'}
 
   ts-api-utils@2.4.0:
     resolution: {integrity: sha512-3TaVTaAv2gTiMB35i3FiGJaRfwb3Pyn/j3m/bfAvGe8FB7CF6u+LMYqYlDh7reQf7UNvoTvdfAqHGmPGOSsPmA==}
@@ -2117,6 +2165,10 @@ packages:
 
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
+  undici@7.24.6:
+    resolution: {integrity: sha512-Xi4agocCbRzt0yYMZGMA6ApD7gvtUFaxm4ZmeacWI4cZxaF6C+8I8QfofC20NAePiB/IcvZmzkJ7XPa471AEtA==}
+    engines: {node: '>=20.18.1'}
 
   unrs-resolver@1.11.1:
     resolution: {integrity: sha512-bSjt9pjaEBnNiGgc9rUiHGKv5l4/TGzDmYw3RhnkJGtLhbnnA/5qJj7x3dNDCRx/PJxu774LlH8lCOlB4hEfKg==}
@@ -2299,6 +2351,18 @@ snapshots:
     dependencies:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
+
+  '@distube/ytdl-core@4.16.12':
+    dependencies:
+      http-cookie-agent: 7.0.3(tough-cookie@5.1.2)(undici@7.24.6)
+      https-proxy-agent: 7.0.6
+      m3u8stream: 0.8.6
+      miniget: 4.2.3
+      sax: 1.6.0
+      tough-cookie: 5.1.2
+      undici: 7.24.6
+    transitivePeerDependencies:
+      - supports-color
 
   '@emnapi/core@1.8.1':
     dependencies:
@@ -2812,6 +2876,8 @@ snapshots:
       acorn: 8.16.0
 
   acorn@8.16.0: {}
+
+  agent-base@7.1.4: {}
 
   ajv@6.14.0:
     dependencies:
@@ -3617,6 +3683,20 @@ snapshots:
     dependencies:
       hermes-estree: 0.25.1
 
+  http-cookie-agent@7.0.3(tough-cookie@5.1.2)(undici@7.24.6):
+    dependencies:
+      agent-base: 7.1.4
+      tough-cookie: 5.1.2
+    optionalDependencies:
+      undici: 7.24.6
+
+  https-proxy-agent@7.0.6:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
   iceberg-js@0.8.1: {}
 
   ignore@5.3.2: {}
@@ -3829,6 +3909,11 @@ snapshots:
     dependencies:
       yallist: 3.1.1
 
+  m3u8stream@0.8.6:
+    dependencies:
+      miniget: 4.2.3
+      sax: 1.6.0
+
   math-intrinsics@1.1.0: {}
 
   merge2@1.4.1: {}
@@ -3837,6 +3922,8 @@ snapshots:
     dependencies:
       braces: 3.0.3
       picomatch: 2.3.1
+
+  miniget@4.2.3: {}
 
   minimatch@10.2.4:
     dependencies:
@@ -4172,6 +4259,8 @@ snapshots:
       es-errors: 1.3.0
       is-regex: 1.2.1
 
+  sax@1.6.0: {}
+
   scheduler@0.27.0: {}
 
   semver@6.3.1: {}
@@ -4399,9 +4488,19 @@ snapshots:
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
 
+  tldts-core@6.1.86: {}
+
+  tldts@6.1.86:
+    dependencies:
+      tldts-core: 6.1.86
+
   to-regex-range@5.0.1:
     dependencies:
       is-number: 7.0.0
+
+  tough-cookie@5.1.2:
+    dependencies:
+      tldts: 6.1.86
 
   ts-api-utils@2.4.0(typescript@5.9.3):
     dependencies:
@@ -4476,6 +4575,8 @@ snapshots:
       which-boxed-primitive: 1.1.1
 
   undici-types@6.21.0: {}
+
+  undici@7.24.6: {}
 
   unrs-resolver@1.11.1:
     dependencies:

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -1,0 +1,10 @@
+{
+  "version": 1,
+  "skills": {
+    "shadcn": {
+      "source": "shadcn/ui",
+      "sourceType": "github",
+      "computedHash": "507f011a70e8b3ae242bdc0bb5b39fd91a1d4049a0f3c281991ccf84973d591c"
+    }
+  }
+}

--- a/src/apps/recipes/recipes-home.container.tsx
+++ b/src/apps/recipes/recipes-home.container.tsx
@@ -545,6 +545,11 @@ export function RecipesHomeContainer() {
     const sourceUrl = addUrl.trim();
     if (!sourceUrl) { setUrlError("URL을 입력해주세요."); return; }
     if (!/^https?:\/\//i.test(sourceUrl)) { setUrlError("http:// 또는 https://로 시작하는 URL을 입력해주세요."); return; }
+    if (inferSourceType(sourceUrl) !== "youtube_shorts") {
+      setUrlError("AI draft generation currently supports YouTube Shorts only. You can still continue manually.");
+      openManualDraft(sourceUrl);
+      return;
+    }
     setUrlError(""); setIsGenerating(true); setSummarizeJobStatus("queued");
     try {
       const handle = await createSummarizeJobRequest({ sourceUrl });
@@ -950,13 +955,20 @@ export function RecipesHomeContainer() {
               <div className="px-5">
                 <h1 className="text-[32px] font-bold leading-tight">Add Recipe</h1>
                 <p className="mt-0.5 text-[10px] font-bold uppercase tracking-[0.14em] text-muted-foreground">Add New Recipe</p>
+                <div className="mt-4 rounded-2xl border border-primary/20 bg-primary/10 p-4">
+                  <p className="text-[10px] font-bold uppercase tracking-[0.14em] text-primary">Current AI Support</p>
+                  <p className="mt-1 text-sm font-semibold">YouTube Shorts only</p>
+                  <p className="mt-1 text-xs leading-relaxed text-muted-foreground">
+                    AI draft generation currently works only with YouTube Shorts links. Other links can still be saved manually.
+                  </p>
+                </div>
 
                 {/* ── Paste URL ── */}
                 <div className="mt-6">
                   <div className="relative">
                     <Input
                       className="h-12 rounded-xl border-0 bg-card pr-12 text-sm focus-visible:ring-1 focus-visible:ring-primary"
-                      placeholder="https://recipe-link.com/..."
+                      placeholder="https://youtube.com/shorts/..."
                       value={addUrl}
                       onChange={(e) => setAddUrl(e.target.value)}
                     />

--- a/src/lib/server/recipes/recipes-extraction.service.ts
+++ b/src/lib/server/recipes/recipes-extraction.service.ts
@@ -1,5 +1,9 @@
 import type { SourceType, SummarizeRecipeInput } from "@/src/apps/recipes/recipes.types";
 import { inferSourceType } from "@/src/lib/server/recipes/recipes.utils";
+import { transcribeRecipeAudio } from "@/src/lib/server/recipes/recipes-transcription.service";
+import { downloadYouTubeRecipeAudio } from "@/src/lib/server/recipes/recipes-youtube-audio.service";
+
+const MIN_RECIPE_NARRATIVE_LENGTH = 120;
 
 type YouTubeCaptionTrack = {
   baseUrl?: string;
@@ -24,9 +28,25 @@ export type ExtractedRecipeContext = {
   canonicalVideoId: string | null;
   title: string;
   description: string;
-  transcript: string;
+  subtitleText: string;
+  transcriptText: string;
   evidenceSources: string[];
 };
+
+function emptyRecipeContext(
+  sourceType: SourceType,
+  canonicalVideoId: string | null = null
+): ExtractedRecipeContext {
+  return {
+    sourceType,
+    canonicalVideoId,
+    title: "",
+    description: "",
+    subtitleText: "",
+    transcriptText: "",
+    evidenceSources: []
+  };
+}
 
 async function fetchText(url: string): Promise<string> {
   const controller = new AbortController();
@@ -196,18 +216,35 @@ async function fetchYouTubeTranscript(baseUrl: string | null): Promise<string> {
   }
 }
 
+async function maybeTranscribeYouTubeAudio(
+  context: Pick<ExtractedRecipeContext, "canonicalVideoId" | "title" | "description" | "subtitleText">
+): Promise<string> {
+  if (!context.canonicalVideoId || context.subtitleText.length >= MIN_RECIPE_NARRATIVE_LENGTH) {
+    return "";
+  }
+
+  const audio = await downloadYouTubeRecipeAudio(context.canonicalVideoId);
+
+  if (!audio) {
+    return "";
+  }
+
+  try {
+    return await transcribeRecipeAudio(audio, {
+      title: context.title,
+      description: context.description
+    });
+  } catch (error) {
+    console.error("Recipe audio transcription failed", error);
+    return "";
+  }
+}
+
 async function fetchYouTubeContext(sourceUrl: string): Promise<ExtractedRecipeContext> {
   const videoId = extractYouTubeVideoId(sourceUrl);
 
   if (!videoId) {
-    return {
-      sourceType: "youtube_shorts",
-      canonicalVideoId: null,
-      title: "",
-      description: "",
-      transcript: "",
-      evidenceSources: []
-    };
+    return emptyRecipeContext("youtube_shorts");
   }
 
   const canonicalUrl = `https://www.youtube.com/watch?v=${videoId}&hl=ko`;
@@ -219,29 +256,47 @@ async function fetchYouTubeContext(sourceUrl: string): Promise<ExtractedRecipeCo
       "var ytInitialPlayerResponse = "
     ) as YouTubePlayerResponse | null;
     const videoDetails = playerResponse?.videoDetails;
-    const transcript = await fetchYouTubeTranscript(pickCaptionTrack(playerResponse));
-    const evidenceSources = ["youtube_metadata"];
+    const subtitleText = await fetchYouTubeTranscript(pickCaptionTrack(playerResponse));
+    const title = normalizeWhitespace(videoDetails?.title ?? "");
+    const description = normalizeWhitespace(videoDetails?.shortDescription ?? "");
+    const transcriptText = await maybeTranscribeYouTubeAudio({
+      canonicalVideoId: videoId,
+      title,
+      description,
+      subtitleText
+    });
+    const evidenceSources: string[] = [];
 
-    if (transcript) {
+    if (title || description) {
+      evidenceSources.push("youtube_metadata");
+    }
+
+    if (subtitleText) {
       evidenceSources.push("youtube_captions");
+    }
+
+    if (transcriptText) {
+      evidenceSources.push("openai_audio_transcription");
     }
 
     return {
       sourceType: "youtube_shorts",
       canonicalVideoId: videoId,
-      title: normalizeWhitespace(videoDetails?.title ?? ""),
-      description: normalizeWhitespace(videoDetails?.shortDescription ?? ""),
-      transcript,
+      title,
+      description,
+      subtitleText,
+      transcriptText,
       evidenceSources
     };
   } catch {
+    const transcriptText = await maybeTranscribeYouTubeAudio(
+      emptyRecipeContext("youtube_shorts", videoId)
+    );
+
     return {
-      sourceType: "youtube_shorts",
-      canonicalVideoId: videoId,
-      title: "",
-      description: "",
-      transcript: "",
-      evidenceSources: []
+      ...emptyRecipeContext("youtube_shorts", videoId),
+      transcriptText,
+      evidenceSources: transcriptText ? ["openai_audio_transcription"] : []
     };
   }
 }
@@ -254,7 +309,12 @@ export async function extractRecipeContext(
   if (sourceType === "youtube_shorts") {
     const youtubeContext = await fetchYouTubeContext(input.sourceUrl);
 
-    if (youtubeContext.title || youtubeContext.description || youtubeContext.transcript) {
+    if (
+      youtubeContext.title ||
+      youtubeContext.description ||
+      youtubeContext.subtitleText ||
+      youtubeContext.transcriptText
+    ) {
       return youtubeContext;
     }
   }
@@ -266,13 +326,17 @@ export async function extractRecipeContext(
     canonicalVideoId: null,
     title: meta.title,
     description: meta.description,
-    transcript: "",
+    subtitleText: "",
+    transcriptText: "",
     evidenceSources: meta.title || meta.description ? ["page_meta"] : []
   };
 }
 
 export function hasSufficientRecipeContext(context: ExtractedRecipeContext): boolean {
-  const transcriptScore = context.transcript.length >= 120;
+  const narrativeText = [context.subtitleText, context.transcriptText]
+    .filter(Boolean)
+    .join(" ");
+  const transcriptScore = narrativeText.length >= MIN_RECIPE_NARRATIVE_LENGTH;
   const metadataScore = `${context.title} ${context.description}`.trim().length >= 24;
 
   return transcriptScore || metadataScore;

--- a/src/lib/server/recipes/recipes-summarize-job-runner.ts
+++ b/src/lib/server/recipes/recipes-summarize-job-runner.ts
@@ -1,4 +1,5 @@
 import {
+  type ExtractedRecipeContext,
   extractRecipeContext,
   hasSufficientRecipeContext
 } from "@/src/lib/server/recipes/recipes-extraction.service";
@@ -22,9 +23,10 @@ export async function runSummarizeJob(jobId: string): Promise<void> {
   }
 
   await markSummarizeJobExtracting(jobId);
+  let context: ExtractedRecipeContext | null = null;
 
   try {
-    const context = await extractRecipeContext({ sourceUrl: job.sourceUrl });
+    context = await extractRecipeContext({ sourceUrl: job.sourceUrl });
 
     await storeSummarizeJobEvidence(jobId, context);
 
@@ -42,9 +44,7 @@ export async function runSummarizeJob(jobId: string): Promise<void> {
     const draft = await summarizeRecipeFromContext(job.sourceUrl, context);
     await completeSummarizeJob(jobId, context, draft);
   } catch (error) {
-    if (error instanceof ApiError && error.status === 400) {
-      const context = await extractRecipeContext({ sourceUrl: job.sourceUrl });
-
+    if (error instanceof ApiError && error.status === 400 && context) {
       await markSummarizeJobInsufficientContext(
         jobId,
         context,

--- a/src/lib/server/recipes/recipes-summarize-jobs.repository.ts
+++ b/src/lib/server/recipes/recipes-summarize-jobs.repository.ts
@@ -10,12 +10,11 @@ import type {
   SummarizeJobHandle,
   SummarizeJobResult,
   SummarizeJobStatus,
-  SummarizeRecipeInput} from "@/src/apps/recipes/recipes.types";
+  SummarizeRecipeInput
+} from "@/src/apps/recipes/recipes.types";
 import { prisma } from "@/src/lib/server/prisma";
 import { inferSourceType } from "@/src/lib/server/recipes/recipes.utils";
-import type {
-  ExtractedRecipeContext
-} from "@/src/lib/server/recipes/recipes-extraction.service";
+import type { ExtractedRecipeContext } from "@/src/lib/server/recipes/recipes-extraction.service";
 
 type SummarizeJobRecord = {
   id: string;
@@ -142,8 +141,8 @@ export async function storeSummarizeJobEvidence(
       canonicalVideoId: context.canonicalVideoId,
       titleHint: context.title || null,
       descriptionHint: context.description || null,
-      subtitleText: context.transcript || null,
-      transcriptText: null,
+      subtitleText: context.subtitleText || null,
+      transcriptText: context.transcriptText || null,
       evidenceSources: context.evidenceSources as Prisma.InputJsonValue,
       updatedAt: new Date()
     }
@@ -172,8 +171,8 @@ export async function completeSummarizeJob(
       canonicalVideoId: context.canonicalVideoId,
       titleHint: context.title || null,
       descriptionHint: context.description || null,
-      subtitleText: context.transcript || null,
-      transcriptText: null,
+      subtitleText: context.subtitleText || null,
+      transcriptText: context.transcriptText || null,
       evidenceSources: context.evidenceSources as Prisma.InputJsonValue,
       confidence: draft.confidence ?? null,
       draftPayload: {
@@ -200,8 +199,8 @@ export async function markSummarizeJobInsufficientContext(
       canonicalVideoId: context.canonicalVideoId,
       titleHint: context.title || null,
       descriptionHint: context.description || null,
-      subtitleText: context.transcript || null,
-      transcriptText: null,
+      subtitleText: context.subtitleText || null,
+      transcriptText: context.transcriptText || null,
       evidenceSources: context.evidenceSources as Prisma.InputJsonValue,
       confidence: 0,
       draftPayload: Prisma.JsonNull,

--- a/src/lib/server/recipes/recipes-summarizer.service.ts
+++ b/src/lib/server/recipes/recipes-summarizer.service.ts
@@ -21,7 +21,8 @@ export async function summarizeRecipeFromContext(
 
   if (context.title) contextLines.push(`제목: ${context.title}`);
   if (context.description) contextLines.push(`설명: ${context.description}`);
-  if (context.transcript) contextLines.push(`자막/음성 전사: ${context.transcript}`);
+  if (context.subtitleText) contextLines.push(`자막: ${context.subtitleText}`);
+  if (context.transcriptText) contextLines.push(`음성 전사(자동): ${context.transcriptText}`);
 
   const prompt = `당신은 요리 레시피 전문가입니다. 아래 동영상 링크 정보를 바탕으로 레시피 초안을 작성해주세요. 모든 내용은 한국어로 작성합니다.
 
@@ -38,6 +39,7 @@ ${contextLines.join("\n")}
 규칙:
 - 재료는 개별 항목으로 나열 (각 항목 앞에 "- " 불필요)
 - 조리 단계는 순서대로, 각 단계는 명확하고 구체적으로
+- 자막과 음성 전사가 모두 있으면 서로 겹치는 사실만 더 강하게 신뢰하세요
 - 문맥에서 확인되지 않은 재료나 단계를 추측으로 채우지 마세요
 - 정확한 요리 종류를 식별할 수 없으면 빈 제목과 빈 배열을 반환하고 confidence를 0으로 설정하세요
 - 제목은 요리 이름만 (예: "간장 계란밥", "떡볶이")`;

--- a/src/lib/server/recipes/recipes-transcription.service.ts
+++ b/src/lib/server/recipes/recipes-transcription.service.ts
@@ -1,0 +1,36 @@
+import OpenAI, { toFile } from "openai";
+
+import type { DownloadedRecipeAudio } from "@/src/lib/server/recipes/recipes-youtube-audio.service";
+
+const DEFAULT_TRANSCRIPTION_MODEL = process.env.OPENAI_TRANSCRIPTION_MODEL ?? "gpt-4o-transcribe";
+
+function hasHangul(text: string): boolean {
+  return /[가-힣]/.test(text);
+}
+
+export async function transcribeRecipeAudio(
+  audio: DownloadedRecipeAudio,
+  hints: { title?: string; description?: string } = {}
+): Promise<string> {
+  const client = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+  const hintText = `${hints.title ?? ""} ${hints.description ?? ""}`.trim();
+  const language = hasHangul(hintText) ? "ko" : undefined;
+  const file = await toFile(audio.buffer, audio.fileName, {
+    type: audio.mimeType
+  });
+  const transcription = await client.audio.transcriptions.create(
+    {
+      file,
+      model: DEFAULT_TRANSCRIPTION_MODEL,
+      language,
+      prompt: language === "ko"
+        ? "한국어 요리 영상 음성을 정확히 받아쓰기 하세요. 음식 이름, 재료명, 양념명, 조리 단계를 가능한 그대로 적으세요."
+        : undefined,
+      response_format: "json",
+      temperature: 0
+    },
+    { timeout: 30000 }
+  );
+
+  return transcription.text.trim();
+}

--- a/src/lib/server/recipes/recipes-youtube-audio.service.ts
+++ b/src/lib/server/recipes/recipes-youtube-audio.service.ts
@@ -1,0 +1,190 @@
+import { Readable } from "node:stream";
+
+import ytdl from "@distube/ytdl-core";
+
+const MAX_TRANSCRIPTION_AUDIO_BYTES = 24 * 1024 * 1024;
+const YOUTUBE_REQUEST_HEADERS = {
+  "User-Agent": "Mozilla/5.0 (compatible; PantryClip/1.0)",
+  "Accept-Language": "ko,en-US;q=0.9,en;q=0.8"
+};
+
+type YouTubeAudioFormat = Awaited<ReturnType<typeof ytdl.getInfo>>["formats"][number];
+
+export type DownloadedRecipeAudio = {
+  buffer: Buffer;
+  fileName: string;
+  mimeType: string;
+  estimatedBytes: number | null;
+};
+
+function parsePositiveInteger(value: string | number | null | undefined): number | null {
+  if (typeof value === "number") {
+    return Number.isFinite(value) && value > 0 ? Math.floor(value) : null;
+  }
+
+  if (typeof value !== "string" || !value.trim()) {
+    return null;
+  }
+
+  const parsed = Number(value);
+  return Number.isFinite(parsed) && parsed > 0 ? Math.floor(parsed) : null;
+}
+
+function estimateFormatSizeBytes(format: YouTubeAudioFormat): number | null {
+  const contentLength = parsePositiveInteger(format.contentLength);
+
+  if (contentLength) {
+    return contentLength;
+  }
+
+  const durationMs = parsePositiveInteger(format.approxDurationMs);
+  const bitrate = format.audioBitrate
+    ? format.audioBitrate * 1_000
+    : format.averageBitrate ?? format.bitrate ?? null;
+
+  if (!durationMs || !bitrate) {
+    return null;
+  }
+
+  return Math.ceil((bitrate / 8) * (durationMs / 1_000));
+}
+
+function containerToExtension(container: string | undefined): string {
+  if (!container) {
+    return "webm";
+  }
+
+  if (container === "mp4") {
+    return "m4a";
+  }
+
+  return container;
+}
+
+function containerToMimeType(container: string | undefined): string {
+  switch (container) {
+    case "mp4":
+      return "audio/mp4";
+    case "webm":
+      return "audio/webm";
+    default:
+      return "application/octet-stream";
+  }
+}
+
+function containerPreference(container: string | undefined): number {
+  if (container === "mp4") {
+    return 2;
+  }
+
+  if (container === "webm") {
+    return 1;
+  }
+
+  return 0;
+}
+
+function pickPreferredAudioFormat(formats: YouTubeAudioFormat[]): YouTubeAudioFormat | null {
+  const candidates = formats
+    .filter((format) => Boolean(format.url) && !format.isHLS && !format.isDashMPD)
+    .map((format) => ({
+      format,
+      estimatedBytes: estimateFormatSizeBytes(format),
+      bitrateScore: format.audioBitrate ?? format.averageBitrate ?? format.bitrate ?? 0,
+      containerScore: containerPreference(format.container)
+    }));
+
+  const withinLimit = candidates.filter(
+    ({ estimatedBytes }) => estimatedBytes === null || estimatedBytes <= MAX_TRANSCRIPTION_AUDIO_BYTES
+  );
+  const pool = withinLimit.length > 0 ? withinLimit : candidates;
+
+  pool.sort((left, right) => {
+    if (right.bitrateScore !== left.bitrateScore) {
+      return right.bitrateScore - left.bitrateScore;
+    }
+
+    if (right.containerScore !== left.containerScore) {
+      return right.containerScore - left.containerScore;
+    }
+
+    if (left.estimatedBytes === null) {
+      return 1;
+    }
+
+    if (right.estimatedBytes === null) {
+      return -1;
+    }
+
+    return left.estimatedBytes - right.estimatedBytes;
+  });
+
+  return pool[0]?.format ?? null;
+}
+
+async function readStreamToBuffer(stream: Readable, maxBytes: number): Promise<Buffer> {
+  return new Promise((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    let totalBytes = 0;
+
+    stream.on("data", (chunk: Buffer | string) => {
+      const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+      totalBytes += buffer.byteLength;
+
+      if (totalBytes > maxBytes) {
+        stream.destroy(new Error("Audio stream exceeded transcription size limit."));
+        return;
+      }
+
+      chunks.push(buffer);
+    });
+
+    stream.once("error", reject);
+    stream.once("end", () => resolve(Buffer.concat(chunks)));
+  });
+}
+
+export async function downloadYouTubeRecipeAudio(
+  canonicalVideoId: string
+): Promise<DownloadedRecipeAudio | null> {
+  try {
+    const watchUrl = `https://www.youtube.com/watch?v=${canonicalVideoId}&hl=ko`;
+    const info = await ytdl.getInfo(watchUrl, {
+      lang: "ko",
+      playerClients: ["WEB", "IOS"],
+      requestOptions: {
+        headers: YOUTUBE_REQUEST_HEADERS
+      }
+    });
+    const format = pickPreferredAudioFormat(ytdl.filterFormats(info.formats, "audioonly"));
+
+    if (!format) {
+      return null;
+    }
+
+    const estimatedBytes = estimateFormatSizeBytes(format);
+
+    if (estimatedBytes && estimatedBytes > MAX_TRANSCRIPTION_AUDIO_BYTES) {
+      return null;
+    }
+
+    const buffer = await readStreamToBuffer(
+      ytdl.downloadFromInfo(info, {
+        format,
+        quality: format.itag,
+        highWaterMark: 1 << 25
+      }),
+      MAX_TRANSCRIPTION_AUDIO_BYTES
+    );
+
+    return {
+      buffer,
+      fileName: `short-${canonicalVideoId}.${containerToExtension(format.container)}`,
+      mimeType: format.mimeType?.split(";")[0] ?? containerToMimeType(format.container),
+      estimatedBytes
+    };
+  } catch (error) {
+    console.error("YouTube audio download failed", error);
+    return null;
+  }
+}


### PR DESCRIPTION
<!-- pr-description:start -->
## Summary
Adds audio transcription fallback for YouTube Shorts summarize jobs and wires it into the extraction and summarization pipeline. Introduces YouTube audio download, transcription service, and related context handling to improve resilience when transcripts are unavailable.

## Changes
- package.json: add dependency @distube/ytdl-core
- pnpm-lock.yaml: update lockfile with new dependency
- skills-lock.json: add skills entry
- src/apps/recipes/recipes-home.container.tsx: enforce YouTube Shorts only for AI draft flow and provide user guidance; add UI hint about current AI support
- src/lib/server/recipes/recipes-extraction.service.ts: introduce transcription and audio download paths; extend ExtractedRecipeContext with subtitleText and transcriptText; add logic to optionally transcribe YouTube audio
- src/lib/server/recipes/recipes-summarize-job-runner.ts: handle context typing and robust error handling when context is present
- src/lib/server/recipes/recipes-summarize-jobs.repository.ts: map new transcript/subtitle fields to database
- src/lib/server/recipes/recipes-summarizer.service.ts: include both subtitleText and transcriptText in draft context and output
- src/lib/server/recipes/recipes-transcription.service.ts: new module to transcribe audio using a transcription model
- src/lib/server/recipes/recipes-youtube-audio.service.ts: new module to download and select appropriate YouTube audio formats for transcription

## Risks
- None identified.

## Testing
- No explicit tests indicated in the patch. Please run integration flow for YouTube Shorts summarize jobs to validate fallback transcription path.
<!-- pr-description:end -->