### PR TITLE
Move summarize jobs to Graphile Worker and add worker-side job diagnostics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,8 +39,6 @@ pnpm-debug.log*
 .DS_Store
 Thumbs.db
 
-# Docs
-docs/
 
 AGENTS.md
 .agents

--- a/README.md
+++ b/README.md
@@ -1,50 +1,95 @@
 # PantryClip
 
-MVP codebase for PantryClip using Next.js App Router + Next.js API Route Handlers.
+PantryClip is a mobile-first Next.js app for turning short-form cooking videos into editable recipe drafts.
 
-## Structure (Blueprint-aligned)
+## Current stack
 
-- `src/app/`: routing shell only (pages/layouts/api route handlers)
+- Next.js App Router
+- React 19 + TypeScript
+- Prisma + PostgreSQL
+- Supabase Auth
+- Zod validation
+- OpenAI-backed summarize pipeline
+- Graphile Worker for background summarize jobs
+
+## Project structure
+
+- `src/app/`: thin pages, layouts, and route handlers
 - `src/apps/`: feature modules and app-level providers
-- `src/apis/`: client-side API callers + DTO types
-- `src/components/`: reusable shared components
-- `src/lib/`: shared libraries/utilities (`react-query`, `axios`, `auth`, server utils)
-- `src/config/`: app/runtime configuration
-- `src/styles/`: global styles
-- `docs/`: planning/product docs
+- `src/apis/`: client-side fetch wrappers and DTOs
+- `src/components/`: shared UI components
+- `src/lib/auth/`: Supabase auth helpers
+- `src/lib/server/`: server-only repositories, services, and worker helpers
+- `src/worker/`: background worker entrypoints and task registration
+- `prisma/`: schema and SQL migrations
+- `docs/`: product and implementation notes
 
 ## Quick start
 
+Install dependencies and generate Prisma types:
+
 ```bash
-npm install
-npm run dev
+pnpm install
 ```
 
-Open `http://localhost:3000`.
+Start the web app:
 
-## API docs (Swagger UI)
+```bash
+pnpm dev
+```
+
+Open [http://localhost:3000](http://localhost:3000).
+
+## Background worker
+
+Summarize jobs are asynchronous. To run them locally:
+
+1. Start the app with `pnpm dev`
+2. Run Graphile Worker migrations:
+
+```bash
+pnpm worker:migrate
+```
+
+3. Start the worker in a second terminal:
+
+```bash
+pnpm worker
+```
+
+Recommended environment setup:
+
+- `DATABASE_URL`: app database connection string
+- `GRAPHILE_WORKER_DATABASE_URL`: optional dedicated worker connection string
+- `OPENAI_API_KEY`
+- `NEXT_PUBLIC_SUPABASE_URL`
+- `NEXT_PUBLIC_SUPABASE_ANON_KEY`
+
+When the web app runs on Vercel and the worker runs elsewhere, keep the app on its normal runtime DB URL and point the dedicated worker at its own connection string.
+
+## API docs
 
 After starting the app, open:
 
-- `http://localhost:3000/api-docs` for interactive Swagger UI
-- `http://localhost:3000/api/openapi` for raw OpenAPI JSON
+- [http://localhost:3000/api-docs](http://localhost:3000/api-docs) for Swagger UI
+- [http://localhost:3000/api/openapi](http://localhost:3000/api/openapi) for raw OpenAPI JSON
 
-## Current status
+## Current behavior
 
-- API route stubs are implemented for:
-  - `GET /api/health`
-  - `POST /api/recipes/summarize`
-  - `POST /api/recipes`
-  - `GET /api/recipes`
-  - `GET /api/recipes/:id`
-  - `PATCH /api/recipes/:id`
-  - `DELETE /api/recipes/:id`
-- Temporary in-memory repository is used as a placeholder.
-- Temporary auth stub uses `DEV_USER_ID` or fallback `dev-user-id`.
+- Supabase email/password auth is live
+- Recipes are persisted with Prisma/Postgres
+- `POST /api/recipes/summarize` creates an async summarize job and returns `202`
+- The client polls job status and either:
+  - fills an AI-generated draft
+  - or opens manual entry if extraction is weak or generation fails
+- AI drafting is currently positioned for YouTube Shorts only
 
-## Next implementation steps
+## Verification
 
-1. Replace auth stub with Supabase Auth session extraction.
-2. Replace in-memory repository with Prisma + Postgres.
-3. Implement OpenAI summarization logic in `POST /api/recipes/summarize`.
-4. Build mobile-first UI screens from the docs.
+Useful local checks:
+
+```bash
+pnpm prisma:generate
+pnpm typecheck
+pnpm lint
+```

--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -1,0 +1,19 @@
+# PLAN
+
+Status: Historical MVP checklist.
+
+This file no longer reflects the current repository state. Auth, persistence, async summarize jobs, and manual fallback are already implemented, and the summarize architecture is no longer a synchronous placeholder flow.
+
+Use these as the current planning references instead:
+
+- [pantryclip-url-to-draft-ingestion-implementation-v2.0.md](./pantryclip-url-to-draft-ingestion-implementation-v2.0.md)
+- [pantryclip-technical-decisions-v1.0.md](./pantryclip-technical-decisions-v1.0.md) for historical baseline decisions
+- [pantryclip-api-design-v1.0.md](./pantryclip-api-design-v1.0.md) for historical API context
+
+Why this file is historical:
+
+- it still describes auth as a stub
+- it still describes persistence as in-memory
+- it still assumes synchronous summarize behavior
+
+Keep this file only as an early-project snapshot, not as the active implementation plan.

--- a/docs/pantryclip-api-design-v1.0.md
+++ b/docs/pantryclip-api-design-v1.0.md
@@ -1,0 +1,280 @@
+# PantryClip API Design v1.0 (MVP)
+
+> Status: Historical baseline.
+>
+> This API draft no longer matches the current summarize flow. The current app uses async summarize jobs, not a synchronous draft-returning summarize response.
+>
+> Current planning reference:
+> [pantryclip-url-to-draft-ingestion-implementation-v2.0.md](./pantryclip-url-to-draft-ingestion-implementation-v2.0.md)
+>
+> Current implementation contract reference:
+> [`src/lib/server/openapi/openapi.spec.ts`](../src/lib/server/openapi/openapi.spec.ts)
+
+## 1. API Principles
+1. Base path: `/api`
+2. Data format: JSON only
+3. Auth model: session-based auth; all recipe endpoints require authenticated user
+4. Multi-tenant safety: every recipe operation is scoped by `user_id`
+5. AI summarize endpoint returns draft data only; persistence happens only via `POST /api/recipes`
+
+## 2. Conventions
+
+### 2.1 Headers
+1. Request: `Content-Type: application/json` (for POST/PATCH)
+2. Response: `Content-Type: application/json`
+
+### 2.2 Success Envelope
+Return resource JSON directly (no outer `data` wrapper) for MVP simplicity.
+
+### 2.3 Error Envelope
+```json
+{
+  "code": "VALIDATION_ERROR",
+  "message": "Invalid request",
+  "details": {
+    "field": "title",
+    "reason": "Required"
+  }
+}
+```
+
+### 2.4 Standard Error Codes
+1. `UNAUTHORIZED` (401)
+2. `FORBIDDEN` (403) reserved
+3. `NOT_FOUND` (404)
+4. `VALIDATION_ERROR` (400)
+5. `INTERNAL_ERROR` (500)
+
+## 3. Resource Models
+
+### 3.1 Recipe
+```json
+{
+  "id": "0e03d1b3-38e0-4c66-81f0-4f9f11111111",
+  "userId": "9a61c3d0-188f-45fb-8cc8-9f1a22222222",
+  "sourceUrl": "https://www.youtube.com/shorts/abc123",
+  "sourceType": "youtube_shorts",
+  "title": "10-Minute Soy Butter Udon",
+  "ingredientsText": "- Udon noodles\\n- Soy sauce\\n- Butter",
+  "stepsText": "1. Boil noodles\\n2. Toss with sauce",
+  "summarySource": "ai",
+  "aiConfidence": 0.86,
+  "createdAt": "2026-03-03T20:01:02.000Z",
+  "updatedAt": "2026-03-03T20:01:02.000Z"
+}
+```
+
+Enums:
+1. `sourceType`: `youtube_shorts` | `instagram_reels` | `other`
+2. `summarySource`: `manual` | `ai`
+
+## 4. Endpoints
+
+### 4.1 Health
+`GET /api/health`
+
+Auth: public
+
+Response `200`:
+```json
+{
+  "ok": true,
+  "service": "pantry-clip-api",
+  "timestamp": "2026-03-03T20:01:02.000Z",
+  "uptimeSec": 1234
+}
+```
+
+---
+
+### 4.2 Summarize Recipe Draft
+`POST /api/recipes/summarize`
+
+Auth: required
+
+Request body:
+```json
+{
+  "sourceUrl": "https://www.youtube.com/shorts/abc123"
+}
+```
+
+Validation:
+1. `sourceUrl` must be a valid URL
+
+Response `200`:
+```json
+{
+  "sourceType": "youtube_shorts",
+  "titleDraft": "Spicy Tuna Mayo Rice Bowl",
+  "ingredientsDraft": "- Tuna\\n- Mayo\\n- Rice",
+  "stepsDraft": "1. Mix tuna and mayo\\n2. Serve over rice",
+  "confidence": 0.78
+}
+```
+
+Error status:
+1. `400` invalid payload
+2. `401` unauthenticated
+3. `500` summarize/internal failure
+
+---
+
+### 4.3 Create Recipe
+`POST /api/recipes`
+
+Auth: required
+
+Request body:
+```json
+{
+  "sourceUrl": "https://www.youtube.com/shorts/abc123",
+  "sourceType": "youtube_shorts",
+  "title": "Spicy Tuna Mayo Rice Bowl",
+  "ingredientsText": "- Tuna\\n- Mayo\\n- Rice",
+  "stepsText": "1. Mix tuna and mayo\\n2. Serve over rice",
+  "summarySource": "ai",
+  "aiConfidence": 0.78
+}
+```
+
+Validation:
+1. `sourceUrl` valid URL
+2. `title` length 1..140
+3. `ingredientsText` min length 1
+4. `stepsText` min length 1
+5. `aiConfidence` nullable, range 0..1
+
+Response `201`: `Recipe`
+
+Error status:
+1. `400` invalid payload
+2. `401` unauthenticated
+3. `500` internal error
+
+---
+
+### 4.4 List Recipes
+`GET /api/recipes?q={query}&limit={1..50}&cursor={opaque}`
+
+Auth: required
+
+Query params:
+1. `q` optional title query (case-insensitive contains)
+2. `limit` optional, default `20`, max `50`
+3. `cursor` optional opaque cursor for pagination
+
+Response `200`:
+```json
+{
+  "items": [
+    {
+      "id": "0e03d1b3-38e0-4c66-81f0-4f9f11111111",
+      "userId": "9a61c3d0-188f-45fb-8cc8-9f1a22222222",
+      "sourceUrl": "https://www.youtube.com/shorts/abc123",
+      "sourceType": "youtube_shorts",
+      "title": "10-Minute Soy Butter Udon",
+      "ingredientsText": "- Udon",
+      "stepsText": "1. Cook",
+      "summarySource": "manual",
+      "aiConfidence": null,
+      "createdAt": "2026-03-03T20:01:02.000Z",
+      "updatedAt": "2026-03-03T20:01:02.000Z"
+    }
+  ],
+  "nextCursor": "eyJjcmVhdGVkQXQiOiIyMDI2LTAzLTAzVDIwOjAxOjAyLjAwMFoiLCJpZCI6IjBlMDNkMWIzLTM4ZTAtNGM2Ni04MWYwLTRmOWYxMTExMTExMSJ9"
+}
+```
+
+Sorting:
+1. `createdAt DESC`
+2. tie-breaker `id DESC`
+
+Error status:
+1. `400` invalid query
+2. `401` unauthenticated
+3. `500` internal error
+
+---
+
+### 4.5 Get Recipe Detail
+`GET /api/recipes/:id`
+
+Auth: required
+
+Response `200`: `Recipe`
+
+Error status:
+1. `401` unauthenticated
+2. `404` missing or not owned
+3. `500` internal error
+
+---
+
+### 4.6 Update Recipe
+`PATCH /api/recipes/:id`
+
+Auth: required
+
+Request body (partial):
+```json
+{
+  "title": "Updated title",
+  "ingredientsText": "- Updated",
+  "stepsText": "1. Updated"
+}
+```
+
+Rules:
+1. At least one updatable field is required
+2. Same validation as create for provided fields
+
+Response `200`: updated `Recipe`
+
+Error status:
+1. `400` invalid payload
+2. `401` unauthenticated
+3. `404` missing or not owned
+4. `500` internal error
+
+---
+
+### 4.7 Delete Recipe
+`DELETE /api/recipes/:id`
+
+Auth: required
+
+Response `200`:
+```json
+{
+  "ok": true
+}
+```
+
+Error status:
+1. `401` unauthenticated
+2. `404` missing or not owned
+3. `500` internal error
+
+## 5. Pagination Contract
+Cursor is an opaque base64-encoded JSON object:
+```json
+{
+  "createdAt": "2026-03-03T20:01:02.000Z",
+  "id": "0e03d1b3-38e0-4c66-81f0-4f9f11111111"
+}
+```
+
+Server applies:
+`(created_at, id) < (cursor.createdAt, cursor.id)`
+
+## 6. Security and Ownership
+1. Auth required for `/api/recipes*`
+2. `user_id` is derived from session, never accepted from client payload
+3. Unauthorized cross-user access returns `404` (resource not found)
+
+## 7. Implementation Notes (Current -> Target)
+1. Current code already exposes these endpoint paths.
+2. Current summarize is stubbed; replace with OpenAI pipeline.
+3. Current repository is in-memory; replace with Postgres implementation.
+4. Add explicit `VALIDATION_ERROR` mapping for Zod errors for contract compliance.

--- a/docs/pantryclip-async-extraction-implementation-v1.0.md
+++ b/docs/pantryclip-async-extraction-implementation-v1.0.md
@@ -1,0 +1,17 @@
+# PantryClip Async Extraction Implementation v1.0
+
+Status: Superseded.
+
+This document described the first implementation plan before the product decision changed and before production testing exposed media-access limits on the current runtime.
+
+Use this document instead:
+
+- [pantryclip-url-to-draft-ingestion-implementation-v2.0.md](./pantryclip-url-to-draft-ingestion-implementation-v2.0.md)
+
+Why this doc is superseded:
+
+- Pass 1 is already implemented
+- Pass 2A was attempted on the current Vercel path and exposed provider blocking during source access
+- the recommended next step is now a dedicated ingestion worker with durable queueing, not more iteration inside `after()`
+
+Keep this file only as historical implementation context.

--- a/docs/pantryclip-async-extraction-plan-v1.0.md
+++ b/docs/pantryclip-async-extraction-plan-v1.0.md
@@ -1,0 +1,17 @@
+# PantryClip Async Extraction Plan v1.0
+
+Status: Superseded.
+
+This document was the first async extraction exploration. It no longer reflects the current product decision or the observed production constraints.
+
+Use this document instead:
+
+- [pantryclip-url-to-draft-ingestion-implementation-v2.0.md](./pantryclip-url-to-draft-ingestion-implementation-v2.0.md)
+
+Why this doc is superseded:
+
+- URL-to-draft is now treated as a signature feature, not a best-effort helper
+- Pass 2A on the current Vercel path exposed real provider blocking (`429`) during YouTube media access
+- the recommended next step is now a dedicated ingestion worker, not further iteration inside the current web runtime
+
+Keep this file only as historical planning context.

--- a/docs/pantryclip-build-plan-v1.0.md
+++ b/docs/pantryclip-build-plan-v1.0.md
@@ -1,0 +1,152 @@
+# PantryClip Build Plan v1.0
+
+## 1. Objective
+Ship a usable web MVP that lets users convert short-video recipe links into AI-drafted, editable, searchable recipe notes.
+
+## 2. Build Principles
+1. Keep scope strictly aligned with PRD v1.0.
+2. Optimize for speed of validation, not completeness.
+3. Treat AI output as draft only; user edit is mandatory before save.
+4. Prioritize mobile-first usability for core flow.
+
+## 3. Delivery Milestones
+
+### Milestone 0: Project Setup (Day 1)
+Deliverables:
+- Next.js app initialized with TypeScript + Tailwind
+- Env/config scaffold for DB, auth, OpenAI
+- Base folder architecture (`ui/domain/server/shared`)
+- CI basics (lint + typecheck)
+
+Exit criteria:
+- `npm run lint` and `npm run typecheck` pass
+- App boots locally with placeholder pages
+
+### Milestone 1: Auth + Data Foundation (Day 2-3)
+Deliverables:
+- Auth provider integrated (pick one: Supabase Auth recommended)
+- DB schema for `users` and `recipes`
+- Migration workflow enabled
+- Server-side auth guards for recipe routes
+
+Exit criteria:
+- Authenticated user can sign in/out
+- DB schema deployed in dev
+- Unauthorized recipe access blocked
+
+### Milestone 2: Core Recipe CRUD (Day 4-5)
+Deliverables:
+- `POST /api/recipes`
+- `GET /api/recipes` (pagination)
+- `GET /api/recipes/:id`
+- `PATCH /api/recipes/:id`
+- `DELETE /api/recipes/:id`
+- Link paste + manual edit UI
+
+Exit criteria:
+- End-to-end create/edit/delete works per user
+- Basic validation and error handling in place
+
+### Milestone 3: Default AI Draft Flow (Day 6-7)
+Deliverables:
+- `POST /api/recipes/summarize`
+- Source link -> AI draft (title, ingredients, steps)
+- Mandatory review/edit step before final save
+- Fallback path when AI fails/timeouts
+
+Exit criteria:
+- User can generate AI draft from link and save edited version
+- AI failure does not block manual completion
+
+### Milestone 4: Search + UX Polish (Day 8)
+Deliverables:
+- Title search on list page
+- Mobile-first readability improvements
+- Loading/empty/error states for key pages
+
+Exit criteria:
+- Users can quickly find recipes by title
+- Core flow is usable on common mobile viewport sizes
+
+### Milestone 5: Analytics + Launch Readiness (Day 9-10)
+Deliverables:
+- Event tracking (`recipe_created`, `recipe_viewed`, `recipe_searched`, `recipe_updated`, `ai_summary_used`)
+- Minimal QA checklist completed
+- Deployment to production
+
+Exit criteria:
+- Events appear in analytics tool
+- Production URL available and core flow validated
+
+## 4. Work Breakdown (Execution Checklist)
+
+### 4.1 Product/Planning
+- [ ] Convert PRD open decisions into explicit choices
+- [ ] Finalize v1 information architecture and screen list
+- [ ] Define acceptance criteria per core user flow
+
+### 4.2 Backend
+- [ ] Implement schema + migrations
+- [ ] Build recipe API endpoints with ownership checks
+- [ ] Add request/response validation (e.g., Zod)
+- [ ] Add structured error handling and logging
+
+### 4.3 AI Integration
+- [ ] Define prompt template for recipe structuring
+- [ ] Implement summarize endpoint with timeout/retry rules
+- [ ] Normalize AI output to safe schema
+- [ ] Require user confirmation/edit before persistence
+
+### 4.4 Frontend
+- [ ] Build link input + AI draft screen
+- [ ] Build edit/review form (title, ingredients, steps)
+- [ ] Build recipe list/detail screens
+- [ ] Build search UX and no-results states
+
+### 4.5 QA and Reliability
+- [ ] Add integration tests for API happy paths
+- [ ] Add negative tests (invalid URL, auth failure, missing fields)
+- [ ] Add smoke test for full create->search->view flow
+- [ ] Verify mobile responsiveness on key breakpoints
+
+### 4.6 DevOps
+- [ ] Set environment variables per stage
+- [ ] Configure deployment and rollback notes
+- [ ] Add monitoring for API errors and latency
+
+## 5. Technical Decisions to Lock This Week
+1. Auth: Supabase Auth vs NextAuth (recommend Supabase Auth for MVP speed)
+2. DB access layer: Prisma vs Drizzle vs Supabase client
+3. AI request strategy: synchronous response vs background job (recommend sync first)
+4. Analytics tool: PostHog vs GA4 (recommend PostHog for product events)
+
+## 6. Risks and Mitigation Plan
+1. AI output quality is inconsistent
+- Mitigation: strict output schema + mandatory user edit step.
+
+2. Scope creep beyond core flow
+- Mitigation: maintain explicit "Not Now" list and weekly scope review.
+
+3. Slow velocity from unresolved technical choices
+- Mitigation: lock core stack decisions by Day 1.
+
+4. Low revisit rate after saving recipes
+- Mitigation: optimize title quality, search relevance, and detail readability before new features.
+
+## 7. Definition of Done for MVP Launch
+1. Authenticated users can complete full flow: link -> AI draft -> edit -> save -> search -> reopen.
+2. Recipe CRUD API is stable and ownership-protected.
+3. Mobile-first UX is functional and readable for core screens.
+4. Event tracking is live for all MVP success metrics.
+5. Production deployment is stable for at least 72 hours without critical errors.
+
+## 8. Immediate Next 5 Actions
+1. Lock auth and DB stack decisions today.
+2. Generate schema/migrations and seed one test user.
+3. Build and test recipe CRUD endpoints.
+4. Implement AI summarize endpoint with strict schema validation.
+5. Build the main mobile flow and run a real cooking-session test.
+
+---
+
+End of Build Plan v1.0

--- a/docs/pantryclip-domain-schema-v1.0.md
+++ b/docs/pantryclip-domain-schema-v1.0.md
@@ -1,0 +1,120 @@
+# PantryClip Domain and Schema v1.0 (MVP)
+
+## 1. Domain Scope (MVP)
+PantryClip MVP supports:
+1. Authenticated user access
+2. Save recipe from short-video URL
+3. AI-assisted draft + manual edit before save
+4. Recipe list (latest first)
+5. Title-based search
+6. Recipe detail/edit/delete
+
+Not included in this schema version:
+1. Pantry inventory
+2. Meal planning
+3. Shopping list
+4. Social features
+5. Nutrition engine
+
+## 2. Domain Model
+
+### 2.1 User
+Represents an authenticated account owner.
+
+Fields:
+1. `id` (UUID)
+2. `email` (unique)
+3. `created_at`
+4. `updated_at`
+
+### 2.2 Recipe
+Represents a user-owned, structured cooking note.
+
+Fields:
+1. `id` (UUID)
+2. `user_id` (FK -> users.id)
+3. `source_url`
+4. `source_type` (`youtube_shorts` | `instagram_reels` | `other`)
+5. `title`
+6. `ingredients_text`
+7. `steps_text`
+8. `summary_source` (`manual` | `ai`)
+9. `ai_confidence` (nullable float 0..1)
+10. `created_at`
+11. `updated_at`
+
+Rules:
+1. Recipe belongs to exactly one user.
+2. All read/write operations are scoped by `user_id`.
+3. `title`, `ingredients_text`, and `steps_text` are required.
+4. `ai_confidence` must be null for manual entries, optional for AI-drafted entries.
+
+## 3. API-Domain Mapping
+1. `POST /api/recipes/summarize`
+  Returns draft payload only (not persisted).
+2. `POST /api/recipes`
+  Persists final reviewed recipe.
+3. `GET /api/recipes`
+  Returns user recipes sorted by `created_at DESC`.
+4. `GET /api/recipes/:id`
+  Returns single user-owned recipe.
+5. `PATCH /api/recipes/:id`
+  Updates editable fields (`title`, `ingredients_text`, `steps_text`, optionally source metadata).
+6. `DELETE /api/recipes/:id`
+  Hard delete in MVP.
+
+## 4. Storage Schema (PostgreSQL)
+
+### 4.1 Enums
+1. `source_type`: `youtube_shorts`, `instagram_reels`, `other`
+2. `summary_source`: `manual`, `ai`
+
+### 4.2 Tables
+1. `users`
+2. `recipes`
+
+### 4.3 Constraints
+1. `users.email` unique and lowercased at app layer
+2. `recipes.user_id` FK with `ON DELETE CASCADE`
+3. `recipes.ai_confidence` constrained to `0 <= value <= 1`
+4. `recipes.title` max length 140
+
+## 5. Index Strategy (MVP)
+1. List page: `(user_id, created_at DESC, id DESC)`
+2. Search by title (case-insensitive):
+  `CREATE INDEX ... ON recipes (user_id, lower(title));`
+3. Ownership detail lookup:
+  Primary key on `id` + ownership filter by `user_id`
+
+## 6. Query Patterns
+1. List:
+  `WHERE user_id = $1 ORDER BY created_at DESC, id DESC LIMIT $2`
+2. Search:
+  `WHERE user_id = $1 AND lower(title) LIKE '%' || lower($2) || '%'`
+3. Detail:
+  `WHERE id = $1 AND user_id = $2`
+
+## 7. Cursor Pagination Shape
+Use opaque cursor from `(created_at, id)` pair.
+
+Cursor decode contract:
+1. `createdAt`: ISO datetime
+2. `id`: UUID
+
+Next page predicate:
+`(created_at, id) < ($createdAt, $id)` with same ordering.
+
+## 8. Validation Contract (App Layer)
+1. `source_url`: valid URL
+2. `title`: trimmed, 1..140 chars
+3. `ingredients_text`: trimmed, min 1
+4. `steps_text`: trimmed, min 1
+5. `summary_source`: enum
+6. `ai_confidence`: nullable, 0..1
+
+## 9. Future-Compatible Extensions (Not in MVP)
+1. `archived_at` for soft delete
+2. Full-text search (`tsvector`) over title + ingredients
+3. `language` field for multilingual support
+4. `recipe_events` table for product analytics
+

--- a/docs/pantryclip-feature-list-v1.0.md
+++ b/docs/pantryclip-feature-list-v1.0.md
@@ -1,0 +1,22 @@
+# PantryClip Feature List v1.0
+
+## 1. MVP Product Features (Target Scope)
+1. Paste video URL (YouTube Shorts / Instagram Reels)
+2. Generate editable recipe draft (title, ingredients, steps)
+3. Manual editing and final save
+4. Personal recipe list view (latest first)
+5. Title-based search
+6. Recipe detail view
+7. Edit recipe
+8. Delete recipe
+9. Authenticated access to own recipes only
+10. Mobile-first responsive experience
+
+## 2. Post-MVP / Not-Now Features
+1. Pantry inventory management
+2. Meal planner
+3. Shopping list generation
+4. Social/community features
+5. Nutrition calculation
+6. Recommendation algorithm
+7. Mobile native app

--- a/docs/pantryclip-pass2-multimodal-implementation-v1.0.md
+++ b/docs/pantryclip-pass2-multimodal-implementation-v1.0.md
@@ -1,0 +1,17 @@
+# PantryClip Pass 2 Multimodal Implementation v1.0
+
+Status: Superseded.
+
+This document described Pass 2 as an extension of the existing lightweight async path. That is no longer the recommended architecture.
+
+Use this document instead:
+
+- [pantryclip-url-to-draft-ingestion-implementation-v2.0.md](./pantryclip-url-to-draft-ingestion-implementation-v2.0.md)
+
+Why this doc is superseded:
+
+- the current Vercel-bound media path is not stable enough to support a signature URL-to-draft feature
+- Pass 2B should only happen after media extraction moves to a dedicated worker
+- the new canonical plan combines worker architecture, audio extraction, and later frame analysis into one rollout path
+
+Keep this file only as historical planning context.

--- a/docs/pantryclip-prd-v1.0.md
+++ b/docs/pantryclip-prd-v1.0.md
@@ -1,0 +1,226 @@
+# PantryClip PRD v1.0
+
+## 1. Overview
+
+### 1.1 Product Name
+PantryClip (팬트리클립)
+
+### 1.2 One-line Summary
+PantryClip helps users turn short-form recipe videos into structured, searchable cooking notes.
+
+### 1.3 Background
+Users frequently save YouTube Shorts and Instagram Reels recipes, but struggle to reuse them because video content is hard to scan and unstructured for actual cooking.
+
+### 1.4 Problem Statement
+Short-form recipe content is easy to save but hard to retrieve and use during cooking. Users need a fast way to convert video-based recipes into clear notes (title, ingredients, steps) they can search and reference.
+
+---
+
+## 2. Goals and Non-Goals
+
+### 2.1 Product Goals (MVP)
+1. Let users save recipe links from Shorts/Reels.
+2. Convert recipe info into a structured format usable while cooking.
+3. Let users browse and search their saved recipes quickly.
+4. Validate whether users actually return to and use saved notes.
+
+### 2.2 Non-Goals (MVP)
+1. Pantry/inventory tracking
+2. Meal planning
+3. Shopping list generation
+4. Social/community features
+5. Nutrition calculation
+6. Recommendation algorithms
+
+---
+
+## 3. Target Users
+
+### 3.1 Primary Segment
+Singles or newly married users who consume many short-form recipe videos.
+
+### 3.2 Profile
+- Age: 25-39
+- Interested in home cooking but non-expert
+- Heavy Shorts/Reels recipe consumption
+- Save content frequently, revisit infrequently
+
+### 3.3 Core User Need
+"Help me capture this quick recipe now and find/use it later when I cook."
+
+---
+
+## 4. MVP Scope
+
+### 4.1 In-Scope Features
+1. Save source URL (YouTube Shorts / Instagram Reels)
+2. Create structured recipe content
+- Default AI-assisted summarization from short video link
+- User review and edit of AI draft before final save
+3. Recipe list view (latest first)
+4. Title-based search
+5. Recipe detail, edit, and delete
+
+### 4.2 Out-of-Scope for v1.0
+Everything listed in Non-Goals section.
+
+### 4.3 Functional Requirements
+1. User can create a recipe record from a source URL.
+2. System infers `source_type` from URL pattern.
+3. System proposes an initial title; user can edit before save.
+4. User can input and edit ingredients and steps as plain text.
+5. User can list recipes with pagination.
+6. User can search recipes by title.
+7. User can view recipe detail and update/delete it.
+8. AI summarization is the default draft path and must remain user-editable before final save.
+
+### 4.4 Non-Functional Requirements
+1. Mobile-first responsive UX.
+2. Initial load target: under 2.5s on standard mobile network for list page.
+3. Basic reliability: no data loss on successful save responses.
+4. Security baseline: authenticated access to own recipes only.
+
+---
+
+## 5. User Experience
+
+### 5.1 Primary Flow
+1. Paste video link
+2. Auto-generate editable title
+3. Fill or refine ingredients/steps (manual or AI-assisted)
+4. Save recipe
+5. Search and reopen from recipe list
+
+### 5.2 UX Principles
+1. One-screen focus on core task (save and structure quickly)
+2. Minimize typing burden
+3. Optimize readability while cooking (clear sectioning, concise text)
+
+---
+
+## 6. Success Metrics
+
+### 6.1 Phase 1: Founder Validation
+1. Store 20+ recipes personally
+2. Reopen recipes 5+ times
+3. Use PantryClip during actual cooking sessions
+
+### 6.2 Phase 2: Early User Validation
+1. 100 signed-up users
+2. Average 10+ saved recipes per activated user
+3. 30%+ 4-week returning user rate
+
+### 6.3 Event Tracking (Minimum)
+1. `recipe_created`
+2. `recipe_viewed`
+3. `recipe_searched`
+4. `recipe_updated`
+5. `ai_summary_used`
+
+---
+
+## 7. Technical Design (MVP)
+
+### 7.1 Recommended Stack
+- Frontend: Next.js (App Router), TypeScript, Tailwind CSS
+- Backend/API: Next.js Route Handlers
+- DB: PostgreSQL (Supabase or managed Postgres)
+- Auth: Supabase Auth or NextAuth
+- AI: OpenAI API (optional path)
+- Deploy: Vercel + managed Postgres
+
+### 7.2 Data Model
+#### `users`
+- `id` uuid (PK)
+- `email` unique
+- `created_at`
+
+#### `recipes`
+- `id` uuid (PK)
+- `user_id` uuid (FK -> users.id)
+- `source_url`
+- `source_type` enum (`youtube_shorts`, `instagram_reels`, `other`)
+- `title`
+- `ingredients_text`
+- `steps_text`
+- `summary_source` enum (`manual`, `ai`)
+- `created_at`
+- `updated_at`
+
+Indexes:
+- `(user_id, created_at desc)`
+- `(user_id, title)`
+
+### 7.3 API Endpoints
+1. `POST /api/recipes`
+2. `GET /api/recipes`
+3. `GET /api/recipes/:id`
+4. `PATCH /api/recipes/:id`
+5. `DELETE /api/recipes/:id`
+6. `POST /api/recipes/summarize`
+
+### 7.4 Architecture Principle
+API-first, domain-first layering:
+- UI layer: presentation only
+- Domain layer: entities/use-cases/validation
+- Server layer: handlers/repositories
+- Shared layer: DTOs/schemas/constants
+
+---
+
+## 8. Milestones and Timeline
+
+### 8.1 Milestone A: Product Definition
+- PRD finalized
+- Wireframe complete
+- DB schema finalized
+
+### 8.2 Milestone B: MVP Build
+- Auth + recipe CRUD complete
+- Search complete
+- AI summarize endpoint complete (optional toggle)
+- Mobile-first UI polish
+
+### 8.3 Milestone C: Validation
+- Personal usage milestone achieved
+- Analytics baseline collected
+- Prioritized backlog for v1.1 created
+
+---
+
+## 9. Risks and Mitigations
+
+1. AI summary quality inconsistency
+- Mitigation: always keep manual edit step before save.
+
+2. Framework-coupled domain logic
+- Mitigation: isolate business logic from UI components.
+
+3. Future mobile migration friction
+- Mitigation: stabilize API contracts and version carefully.
+
+4. Low revisit behavior despite saves
+- Mitigation: optimize search and recipe readability first, before adding new feature scope.
+
+---
+
+## 10. Open Decisions
+
+1. Auth provider choice: Supabase Auth vs NextAuth
+2. AI usage policy: default off vs opt-in prompt
+3. Search evolution: title-only vs title + ingredients in v1.1
+4. Initial language support: Korean only vs bilingual
+
+---
+
+## 11. Definition of Done (MVP)
+
+1. User can create/read/update/delete own recipe records securely.
+2. User can search recipes by title with acceptable speed.
+3. Mobile web UX supports full core flow end-to-end.
+4. Analytics events for create/view/search are recorded.
+5. Product is used in real cooking context and meets Phase 1 validation criteria.
+
+---
+
+End of PRD v1.0

--- a/docs/pantryclip-product-planning-v1.0.md
+++ b/docs/pantryclip-product-planning-v1.0.md
@@ -1,0 +1,247 @@
+# PantryClip Product Planning v1.0
+
+## 1. Purpose
+Define the non-code planning artifacts needed before implementation:
+- Domain/schema design
+- API contract design
+- User flow and information architecture
+- UI/UX structure and interaction rules
+
+## 2. Product Scope Boundary (v1.0)
+In scope:
+1. Link input (YouTube Shorts / Instagram Reels)
+2. Default AI draft generation
+3. User review/edit before save
+4. Recipe list and detail
+5. Title search
+6. Recipe update/delete
+
+Out of scope:
+1. Pantry inventory
+2. Shopping list
+3. Social/community
+4. Recommendation engine
+
+## 3. Information Architecture
+
+### 3.1 Core Objects
+1. User
+2. Recipe
+3. AI Draft Session (optional transient object, may not be persisted)
+
+### 3.2 Screen Map (Mobile-first)
+1. Auth
+- Sign in / sign up
+
+2. Recipe Home
+- Search bar
+- Recipe list (latest first)
+- CTA: "Add recipe"
+
+3. Add Recipe
+- URL input
+- "Generate with AI" action
+- Loading/failed states
+
+4. Review Draft
+- Editable fields: title, ingredients, steps
+- Save button
+- Retry AI button (optional)
+
+5. Recipe Detail
+- Full structured content
+- Edit / Delete actions
+
+6. Edit Recipe
+- Same form as Review Draft (without generation step)
+
+## 4. User Flow Design
+
+### 4.1 Primary Flow (Happy Path)
+1. User pastes short-video URL
+2. System validates URL format and infers source type
+3. System requests AI draft
+4. User reviews and edits title/ingredients/steps
+5. User saves recipe
+6. User returns to list, can search and reopen recipe
+
+### 4.2 Edge Flow A: AI Failure
+1. AI draft fails (timeout/invalid response)
+2. System shows failure reason + action options
+3. User either retries AI or continues with manual editing
+4. User can still save recipe manually
+
+### 4.3 Edge Flow B: Poor AI Draft
+1. AI returns low-quality/incomplete output
+2. User edits all fields directly
+3. Save succeeds and marks source as AI-assisted
+
+### 4.4 Edge Flow C: Duplicate/Similar Link
+1. User enters a link already saved
+2. System warns "similar link exists" (soft warning)
+3. User can continue to save as separate note
+
+## 5. UI/UX Planning
+
+### 5.1 UX Principles
+1. One core job per screen
+2. Strong readability for cooking context
+3. Reduce cognitive load during editing
+4. Never block user due to AI quality
+
+### 5.2 Form Design Rules
+1. Title is single-line input, max length enforced
+2. Ingredients and steps use multiline fields
+3. Auto-save is not required in v1.0; explicit save only
+4. Validation errors appear inline near each field
+
+### 5.3 Empty / Loading / Error States
+1. Empty list: explain value + show add CTA
+2. AI loading: progress text + cancel/back option
+3. AI error: retry + manual continue actions
+4. Search no-result: preserve query + show clear button
+
+### 5.4 Accessibility Baseline
+1. Minimum body text size for mobile readability
+2. Sufficient color contrast
+3. All key actions reachable by keyboard
+4. Labels for inputs and buttons
+
+### 5.5 Wireframe Checklist
+1. Auth screen
+2. Home/list screen
+3. Add-link screen
+4. AI-review/edit screen
+5. Detail screen
+6. Edit confirmation + delete confirmation modal
+
+## 6. Schema Planning
+
+### 6.1 `users`
+- `id` uuid PK
+- `email` unique not null
+- `created_at` timestamp not null default now
+
+### 6.2 `recipes`
+- `id` uuid PK
+- `user_id` uuid FK -> users.id not null
+- `source_url` text not null
+- `source_type` enum(`youtube_shorts`,`instagram_reels`,`other`) not null
+- `title` varchar(140) not null
+- `ingredients_text` text not null
+- `steps_text` text not null
+- `summary_source` enum(`manual`,`ai`) not null default `ai`
+- `ai_confidence` numeric nullable
+- `created_at` timestamp not null default now
+- `updated_at` timestamp not null default now
+
+### 6.3 Suggested Constraints
+1. `source_url` must be valid URL format
+2. `title` length between 1 and 140
+3. `ingredients_text` and `steps_text` cannot be empty at save time
+
+### 6.4 Suggested Indexes
+1. `(user_id, created_at desc)`
+2. `(user_id, title)`
+3. Optional dedupe helper: `(user_id, source_url)` non-unique
+
+## 7. API Contract Planning
+
+### 7.1 Endpoint Set (v1.0)
+1. `POST /api/recipes/summarize`
+2. `POST /api/recipes`
+3. `GET /api/recipes`
+4. `GET /api/recipes/:id`
+5. `PATCH /api/recipes/:id`
+6. `DELETE /api/recipes/:id`
+
+### 7.2 Contract: `POST /api/recipes/summarize`
+Request:
+- `sourceUrl: string`
+
+Response:
+- `sourceType: "youtube_shorts" | "instagram_reels" | "other"`
+- `titleDraft: string`
+- `ingredientsDraft: string`
+- `stepsDraft: string`
+- `confidence?: number`
+
+Rules:
+1. This endpoint does not persist recipe data.
+2. Client must require user review/edit before save.
+
+### 7.3 Contract: `POST /api/recipes`
+Request:
+- `sourceUrl: string`
+- `sourceType: enum`
+- `title: string`
+- `ingredientsText: string`
+- `stepsText: string`
+- `summarySource: "manual" | "ai"`
+
+Response:
+- `id`
+- full recipe object
+
+Rules:
+1. Server validates ownership from auth context.
+2. Server normalizes whitespace and trims fields.
+
+### 7.4 Contract: `GET /api/recipes`
+Query:
+- `q?: string` (title search)
+- `cursor?: string`
+- `limit?: number` (default 20, max 50)
+
+Response:
+- `items: Recipe[]`
+- `nextCursor?: string`
+
+### 7.5 Error Model (all endpoints)
+Standard error shape:
+- `code` (e.g., `INVALID_INPUT`, `UNAUTHORIZED`, `NOT_FOUND`, `AI_TIMEOUT`)
+- `message`
+- `details?`
+
+## 8. Data + UX Mapping
+1. URL input -> `source_url`, inferred `source_type`
+2. AI draft fields -> form defaults only (not persisted yet)
+3. User edits -> final persisted fields
+4. Search input -> query `q` against indexed title
+5. Detail/edit/delete -> operations on `recipe.id` under owner scope
+
+## 9. Planning Decisions to Finalize Before Build
+1. URL ingestion policy
+- Option A: user-provided caption/transcript required
+- Option B: URL-only best effort (faster UX, higher AI risk)
+
+2. Draft persistence strategy
+- Option A: keep draft client-side only (simple)
+- Option B: store draft server-side for recovery (more work)
+
+3. Duplicate handling policy
+- Option A: soft warning only (recommended)
+- Option B: hard block duplicate URLs
+
+4. Search scope in v1.0
+- Option A: title only (recommended)
+- Option B: title + ingredients (heavier indexing)
+
+## 10. Design Deliverables Checklist
+1. User flow diagram (happy + edge)
+2. Low-fi wireframes for all 6 core screens
+3. API schema doc (request/response examples)
+4. ERD for `users` and `recipes`
+5. UX copy sheet (button labels, error messages, empty states)
+6. QA acceptance criteria per flow
+
+## 11. Recommended Sequence (Non-Technical Planning First)
+1. Finalize user flow + edge cases
+2. Freeze screen map and wireframes
+3. Freeze schema and API contracts
+4. Write acceptance criteria and UX copy
+5. Start implementation with minimal ambiguity
+
+---
+
+End of Product Planning v1.0

--- a/docs/pantryclip-project-brief-v0.1.md
+++ b/docs/pantryclip-project-brief-v0.1.md
@@ -1,0 +1,190 @@
+# PantryClip (팬트리클립) — Project Brief v0.1
+
+## 1. Core Problem Statement
+
+유튜브 쇼츠 / 인스타 릴스 레시피를 가장 간단한 형태로 구조화해서 요리 노트로 저장하고 싶다.
+
+짧은 영상 기반 레시피는 저장은 쉽지만:
+- 다시 찾기 어렵고
+- 내용이 구조화되어 있지 않으며
+- 실제 요리할 때 참고하기 불편하다
+
+PantryClip은 이를 "요리용 노트" 형태로 재정리해주는 도구다.
+
+## 2. Target User
+
+유튜브 쇼츠로 레시피를 많이 저장하는 자취 / 신혼 사용자
+
+특징:
+- 25~39세
+- 요리에 관심은 많지만 전문적이지는 않음
+- 쇼츠/릴스 기반으로 레시피 소비
+- 저장은 많이 하지만 실제로 다시 보는 경우는 적음
+
+## 3. Product Positioning
+
+"쇼츠 레시피 전용 정리툴"
+
+일반 레시피 앱이 아니라,
+짧은 영상 기반 콘텐츠를 구조화하는 데 집중한다.
+
+핵심은 재고관리도, 식단관리도 아님.
+"영상 -> 구조화된 레시피" 변환에 집중.
+
+## 4. MVP Scope (v0.1)
+
+### Must-have features
+1. 영상 링크 저장 (YouTube Shorts / Instagram Reels)
+2. 레시피 텍스트 정리 (수동 입력 또는 AI 요약)
+3. 나만의 레시피 리스트 조회
+4. 검색 기능 (제목 기준)
+
+### Not now
+- 냉장고 재고 관리
+- 식단 플래너
+- 쇼핑 리스트
+- 커뮤니티 / 소셜 기능
+- 영양 정보 계산
+- 자동 추천 알고리즘
+
+## 5. UX Flow (Simple Version)
+
+1. 링크 붙여넣기
+2. 제목 자동 생성
+3. 재료 / 조리법 구조화
+4. 저장
+5. 리스트에서 검색 및 열람
+
+모든 과정은 모바일 화면 기준으로 단순하게.
+
+## 6. Platform Strategy
+
+### Initial phase
+- Web MVP
+- Mobile-first responsive design
+
+이유:
+- 개발 속도 최적화
+- 빠른 실험 가능
+- 유지보수 비용 최소화
+
+### Long-term
+- 앱 출시 가능성 있음
+- Web 구조를 API 중심으로 설계하여 향후 React Native / Flutter 등으로 마이그레이션 고려
+
+## 7. Success Criteria (Early Stage)
+
+초기 목표는 "나 스스로 잘 쓰는가".
+
+### First milestone
+- 나 혼자 20개 이상 레시피 저장
+- 실제로 5회 이상 다시 열람
+- 요리할 때 앱을 실제 참고
+
+### Second milestone (later)
+- 100명 가입
+- 평균 저장 10개 이상
+- 재방문율 30% 이상
+
+## 8. Current Status
+
+- 이름 확정: PantryClip
+- 포지셔닝 확정
+- MVP 방향성 확정
+
+다음 단계:
+- 간단한 와이어프레임 설계
+- DB 스키마 설계
+- 개발 시작
+
+---
+
+## 9. Technical Structure (for MVP Build)
+
+### 9.1 Recommended Stack
+- Frontend: Next.js (App Router) + TypeScript + Tailwind CSS
+- Backend/API: Next.js Route Handlers (or separate Node API later)
+- Database: PostgreSQL (Supabase or managed Postgres)
+- Auth: Supabase Auth or NextAuth (email/social login)
+- AI summarization: OpenAI API (optional per recipe)
+- Deployment: Vercel (app) + managed Postgres
+
+### 9.2 Core Data Model (MVP)
+- `users`
+  - `id` (uuid, pk)
+  - `email` (unique)
+  - `created_at`
+- `recipes`
+  - `id` (uuid, pk)
+  - `user_id` (fk -> users.id)
+  - `source_url`
+  - `source_type` (youtube_shorts | instagram_reels | other)
+  - `title`
+  - `ingredients_text`
+  - `steps_text`
+  - `summary_source` (manual | ai)
+  - `created_at`
+  - `updated_at`
+
+Indexes:
+- `(user_id, created_at desc)` for list pages
+- `(user_id, title)` for title search
+
+### 9.3 API Boundaries (MVP)
+- `POST /api/recipes`: create recipe from link + structured text
+- `GET /api/recipes`: list user recipes (pagination)
+- `GET /api/recipes/:id`: get detail
+- `PATCH /api/recipes/:id`: update title/ingredients/steps
+- `DELETE /api/recipes/:id`: delete recipe
+- `POST /api/recipes/summarize`: generate AI summary from user-provided text/caption
+
+### 9.4 UX-to-Data Mapping
+- Paste link -> store `source_url`, infer `source_type`
+- Auto title generation -> seed `title` (editable)
+- Ingredient/step structuring -> store in `ingredients_text`, `steps_text`
+- Save -> `recipes` insert
+- Search by title -> indexed query by `user_id + title`
+
+---
+
+## 10. App Migration Strategy (Web -> Mobile)
+
+### 10.1 Architecture Principle
+Adopt an API-first and domain-first architecture from day one:
+- Keep UI logic and domain logic separated.
+- Keep data access behind API/service boundaries.
+- Avoid frontend-coupled DB access in page components.
+
+### 10.2 Migration-ready Structure
+- `app/` or `src/ui/`: web presentation layer only
+- `src/domain/`: entities, validation, use-cases
+- `src/server/`: API handlers and repository adapters
+- `src/shared/`: DTOs, schemas, constants
+
+This allows reuse of domain/shared layers when building mobile clients.
+
+### 10.3 Incremental Migration Path
+1. Build and validate PMF with web MVP
+2. Stabilize API contracts (`/api/recipes` family)
+3. Introduce token-based auth flow usable by mobile clients
+4. Build React Native/Flutter app as API consumer
+5. Keep web + mobile parity via shared API/versioning
+
+### 10.4 Risks and Mitigation
+- Risk: web implementation tightly coupled to framework internals
+  - Mitigation: keep business logic in framework-agnostic services
+- Risk: schema changes break mobile clients later
+  - Mitigation: API versioning and backward-compatible fields
+- Risk: AI summarization variability
+  - Mitigation: always allow manual edit before final save
+
+### 10.5 Definition of Done for Migration-readiness
+- Domain logic not tied to web UI components
+- API contracts documented and stable
+- DB schema migration history managed (Prisma/Drizzle/Supabase migrations)
+- Auth and permission checks centralized
+- Mobile client can create/read/update recipe records via public API contracts
+
+---
+
+End of v0.1 document.

--- a/docs/pantryclip-technical-decisions-v1.0.md
+++ b/docs/pantryclip-technical-decisions-v1.0.md
@@ -1,0 +1,126 @@
+# PantryClip Technical Decisions v1.0
+
+> Status: Historical baseline.
+>
+> This document no longer reflects the current summarize architecture. In particular, it still assumes a synchronous summarize endpoint and client-only draft strategy.
+>
+> Current planning reference:
+> [pantryclip-url-to-draft-ingestion-implementation-v2.0.md](./pantryclip-url-to-draft-ingestion-implementation-v2.0.md)
+
+## 1. Purpose
+Lock MVP technical decisions so implementation can proceed without re-opening foundational choices.
+
+## 2. Locked Decisions (MVP)
+
+1. Application stack
+- Decision: Next.js (App Router) + TypeScript + Tailwind CSS.
+- Why: Matches existing planning docs and enables fast full-stack delivery.
+
+2. API architecture
+- Decision: Use Next.js Route Handlers for MVP API (`/api/recipes*`).
+- Why: Single deployment unit, lower operational overhead, easy transition to separate API later.
+
+3. Data storage
+- Decision: PostgreSQL on Supabase.
+- Why: Managed Postgres + migrations + good fit for relational recipe/user model.
+
+4. Authentication
+- Decision: Supabase Auth (email/password first).
+- Why: Fastest MVP path with built-in session management and straightforward RLS-compatible model.
+
+5. ORM / DB access layer
+- Decision: Prisma as the primary DB access layer.
+- Why: Strong schema/migration workflow and team productivity for CRUD-heavy MVP.
+
+6. AI provider and flow
+- Decision: OpenAI API with synchronous summarize endpoint (`POST /api/recipes/summarize`) in MVP.
+- Why: Simplest flow; avoids queue/background-job complexity until scale requires async.
+
+7. AI draft policy
+- Decision: AI output is draft-only and never auto-saved. User review/edit is mandatory before `POST /api/recipes`.
+- Why: Controls AI quality risk and keeps user ownership of final recipe content.
+
+8. URL ingestion policy
+- Decision: URL-only best-effort summarization. If summarization fails, user can continue manually without blocking.
+- Why: Lowest-friction UX and preserves completion path under AI failure.
+
+9. Draft persistence strategy
+- Decision: Keep AI draft client-side only for v1.0 (no server draft table).
+- Why: Reduces schema/API scope; final persistence happens only on explicit save.
+
+10. Duplicate link handling
+- Decision: Soft warning on possible duplicate `(user_id, source_url)`; allow save.
+- Why: Users may intentionally store multiple notes for same source.
+
+11. Search scope
+- Decision: Title-only search for v1.0 (`q` on `title`), indexed by `(user_id, title)`.
+- Why: Meets MVP need with simpler indexing and predictable performance.
+
+12. Analytics
+- Decision: PostHog for product analytics.
+- Why: Event-centric tracking aligns with MVP success metrics and fast instrumentation.
+
+13. Error contract
+- Decision: Standard error payload across endpoints:
+  - `code`
+  - `message`
+  - `details?`
+- Why: Consistent client handling and easier QA.
+
+## 3. Schema Baseline
+
+### `users`
+- `id` uuid PK
+- `email` unique not null
+- `created_at` timestamp default now
+
+### `recipes`
+- `id` uuid PK
+- `user_id` uuid FK -> `users.id` not null
+- `source_url` text not null
+- `source_type` enum(`youtube_shorts`,`instagram_reels`,`other`) not null
+- `title` varchar(140) not null
+- `ingredients_text` text not null
+- `steps_text` text not null
+- `summary_source` enum(`manual`,`ai`) not null default `ai`
+- `ai_confidence` numeric nullable
+- `created_at` timestamp default now
+- `updated_at` timestamp default now
+
+### Indexes
+- `(user_id, created_at desc)`
+- `(user_id, title)`
+- `(user_id, source_url)` non-unique (duplicate warning helper)
+
+## 4. API Baseline
+
+1. `POST /api/recipes/summarize`
+2. `POST /api/recipes`
+3. `GET /api/recipes`
+4. `GET /api/recipes/:id`
+5. `PATCH /api/recipes/:id`
+6. `DELETE /api/recipes/:id`
+
+### API Rules
+- All recipe endpoints are authenticated and owner-scoped.
+- `summarize` does not persist recipe data.
+- Server trims and normalizes text fields before persistence.
+- `GET /api/recipes` supports cursor pagination (`limit` default 20, max 50).
+
+## 5. Non-Functional Targets (MVP)
+
+1. Mobile-first web UX for all core flows.
+2. List page initial load target under 2.5s on standard mobile network.
+3. No data loss after successful save response.
+4. 72-hour post-launch stability with no critical errors.
+
+## 6. Deferred to v1.1+
+
+1. Ingredient/step full-text search.
+2. Server-side draft recovery.
+3. Async AI jobs with queue/retry workers.
+4. Multi-language support beyond initial launch language.
+
+---
+
+Status: Approved baseline for MVP implementation.

--- a/docs/pantryclip-url-to-draft-ingestion-implementation-v2.0.md
+++ b/docs/pantryclip-url-to-draft-ingestion-implementation-v2.0.md
@@ -1,0 +1,475 @@
+# PantryClip URL-to-Draft Ingestion Implementation v2.0
+
+## 1. Decision
+
+URL-to-draft is a signature feature for PantryClip.
+
+That changes the architecture decision:
+
+- URL ingestion can no longer be treated as a best-effort helper inside the web runtime.
+- Media extraction must become a dedicated product capability with its own worker, retries, observability, and failure handling.
+- The current Vercel `after()` path is a stepping stone, not the long-term implementation.
+
+## 2. Current Problem
+
+The current summarize pipeline already proved an important point:
+
+1. Prompting is not the main bottleneck.
+2. Evidence acquisition is the main bottleneck.
+3. Serverless Vercel execution is the wrong operational shape for media extraction.
+
+### 2.1 Observed production limitation
+
+Current Pass 2A attempts to download YouTube Shorts audio inside the summarize job path.
+
+Observed behavior:
+
+- the app creates the summarize job successfully
+- the background execution starts
+- YouTube audio download is attempted from Vercel serverless runtime
+- YouTube returns `429`
+- the job falls back to weak evidence or `insufficient_context`
+
+This means the current failure is not primarily "AI quality."
+It is "source platform access is unreliable from the current runtime."
+
+### 2.2 Root architectural limitations
+
+1. The current worker runs through Next.js `after()`
+- good for light background work
+- not good for media download, retries, rate limits, or binary-based processing
+
+2. The current extractor uses unofficial source access
+- practical, but brittle
+- subject to platform throttling and behavior changes
+
+3. The current runtime does not control egress well enough
+- shared cloud/serverless IP reputation is a real constraint
+
+4. The pipeline still bundles source access, extraction, and summarization too tightly
+- we need clearer separation between:
+  - source acquisition
+  - evidence extraction
+  - evidence fusion
+  - final draft synthesis
+
+## 3. Recommendation Summary
+
+Build a dedicated ingestion layer and move summarize jobs off the web runtime.
+
+Recommended architecture:
+
+1. Keep the web app on Vercel.
+2. Keep job records in Postgres.
+3. Add a dedicated worker service on non-Vercel compute.
+4. Use a Postgres-backed queue so the repo stays operationally simple.
+5. Replace `@distube/ytdl-core` as the primary extraction path with worker-side media tooling.
+6. Treat frame analysis as a later step that depends on stable media access.
+
+## 4. Recommended Stack
+
+### 4.1 Web app
+
+- Next.js on Vercel
+- existing route handlers remain the API surface
+- the app creates jobs and polls status only
+
+### 4.2 Queue and worker orchestration
+
+Recommended choice:
+
+- Graphile Worker
+
+Why this is the recommendation:
+
+- uses PostgreSQL, which PantryClip already depends on
+- avoids introducing Redis or a second queue system immediately
+- supports durable background jobs, retries, and exponential backoff
+- works well with a separate dedicated Node worker service
+
+### 4.3 Worker runtime
+
+Recommended shape:
+
+- dedicated Node worker service
+- deployed outside Vercel
+- long-lived process
+- controlled outbound network
+- local temporary disk available
+- binaries installed in the worker image
+
+Practical requirement:
+
+- the worker must be able to run `yt-dlp` and `ffmpeg`
+
+### 4.4 Media extraction tools
+
+- `yt-dlp` for metadata, subtitles, and media access
+- `ffmpeg` for audio extraction and later frame sampling
+
+### 4.5 AI services
+
+- OpenAI transcription API for extracted audio
+- OpenAI image/vision input later for frame analysis
+- existing final recipe summarizer can remain a separate stage
+
+## 5. What Changes In The Product Model
+
+Because URL-to-draft is core, PantryClip should behave like an ingestion system:
+
+1. User submits URL
+2. PantryClip records a job
+3. PantryClip extracts evidence in durable background infrastructure
+4. PantryClip either:
+   - produces a draft from strong evidence, or
+   - explains the extraction failure clearly
+
+This means "source blocked" should become a first-class system state.
+It should not look like a mysterious AI failure.
+
+## 6. Target Architecture
+
+### 6.1 High-level flow
+
+```text
+Client -> POST /api/recipes/summarize
+       -> create summarize_jobs row
+       -> enqueue graphile_worker job
+       -> return 202 + jobId
+
+Dedicated worker -> load summarize job
+                 -> extract metadata/subtitles
+                 -> if needed: download media
+                 -> transcribe audio
+                 -> if still needed: sample frames later
+                 -> synthesize recipe draft
+                 -> update summarize_jobs
+
+Client -> GET /api/recipes/summarize/:jobId
+       -> poll until terminal status
+```
+
+### 6.2 Client-facing status vs internal stage
+
+Keep the current client-facing `status` field:
+
+- `queued`
+- `extracting`
+- `summarizing`
+- `completed`
+- `insufficient_context`
+- `failed`
+
+Add an internal `stage` field for operational visibility:
+
+- `queued`
+- `extracting_metadata`
+- `extracting_subtitles`
+- `downloading_media`
+- `transcribing_audio`
+- `extracting_frames`
+- `analyzing_frames`
+- `summarizing`
+- `completed`
+- `insufficient_context`
+- `failed`
+
+This lets the UI stay simple while the worker becomes debuggable.
+
+## 7. Recommended Repo Changes
+
+### 7.1 API layer
+
+Keep:
+
+- `POST /api/recipes/summarize`
+- `GET /api/recipes/summarize/:jobId`
+
+Change:
+
+- remove execution via `after()`
+- replace it with job enqueue only
+
+### 7.2 Worker entry points
+
+Recommended additions:
+
+- `src/worker/tasks/recipes-summarize.task.ts`
+- `src/worker/task-list.ts`
+- `src/worker/worker.ts`
+
+### 7.3 Server modules
+
+Recommended additions/refactors:
+
+- `src/lib/server/recipes/recipes-source-extractor.service.ts`
+- `src/lib/server/recipes/recipes-ytdlp.service.ts`
+- `src/lib/server/recipes/recipes-media-download.service.ts`
+- `src/lib/server/recipes/recipes-audio.service.ts`
+- `src/lib/server/recipes/recipes-transcription.service.ts`
+- `src/lib/server/recipes/recipes-frame-extraction.service.ts`
+- `src/lib/server/recipes/recipes-vision.service.ts`
+- `src/lib/server/recipes/recipes-evidence-fusion.service.ts`
+- `src/lib/server/recipes/recipes-summarizer.service.ts`
+
+### 7.4 Package/runtime additions
+
+Expected additions:
+
+- `graphile-worker`
+- `yt-dlp` available in worker image
+- `ffmpeg` available in worker image
+
+Optional helper additions:
+
+- `execa` for shelling out to media tools
+- lightweight structured logging helper
+
+## 8. Data Model Changes
+
+The existing `SummarizeJob` model is a good foundation, but it needs operational fields.
+
+Recommended additions:
+
+- `stage`
+- `attemptCount`
+- `lastAttemptAt`
+- `providerCode`
+- `providerMessage`
+- `failureKind`
+- `visionNotes`
+- `mediaDebug`
+
+Recommended `failureKind` values:
+
+- `SOURCE_RATE_LIMITED`
+- `SOURCE_UNAVAILABLE`
+- `MEDIA_DOWNLOAD_FAILED`
+- `TRANSCRIPTION_FAILED`
+- `VISION_FAILED`
+- `INSUFFICIENT_CONTEXT`
+- `INTERNAL_ERROR`
+
+Why these fields matter:
+
+- explain failures to users and to us
+- separate source blocking from AI quality
+- support retries and future analytics
+
+## 9. Queueing Strategy
+
+### 9.1 Job creation
+
+`POST /api/recipes/summarize` should do only this:
+
+1. validate input
+2. require auth
+3. create summarize job row
+4. enqueue worker job with `jobId`
+5. return `202`
+
+### 9.2 Worker responsibilities
+
+The worker should own:
+
+1. stage updates
+2. retries
+3. evidence extraction
+4. provider error classification
+5. final summarize step
+
+### 9.3 Retry policy
+
+Retry only retryable source failures.
+
+Suggested retryable cases:
+
+- temporary network errors
+- source throttling/rate limit
+- transient transcription provider failure
+
+Suggested non-retryable cases:
+
+- invalid or unsupported URL
+- missing video
+- media too large after compression strategy
+- persistent insufficient context
+
+## 10. Evidence Extraction Pipeline
+
+### Step 1: Normalize source
+
+- validate YouTube Shorts URL
+- derive canonical video ID
+- normalize to canonical watch URL for downstream processing
+
+### Step 2: Metadata and subtitles
+
+- fetch title/description
+- attempt subtitle or auto-subtitle extraction first
+- score subtitle usefulness
+
+### Step 3: Media download
+
+If subtitle evidence is weak:
+
+- attempt worker-side media access with `yt-dlp`
+- record any provider block or throttle code
+- cache results by canonical video ID where practical
+
+### Step 4: Audio extraction
+
+- use `ffmpeg` to create a transcription-friendly audio file
+- compress to stay within transcription limits
+- chunk only if necessary
+
+### Step 5: Transcription
+
+- transcribe audio with OpenAI
+- store transcript separately from subtitles
+- preserve evidence source tags
+
+### Step 6: Evidence fusion
+
+Combine:
+
+- title
+- description
+- subtitles
+- transcript
+- later: vision notes
+
+Then score evidence quality before recipe synthesis.
+
+### Step 7: Final draft synthesis
+
+Only when evidence is strong enough:
+
+- call the recipe summarizer
+- validate structured output
+- save draft payload and confidence
+
+## 11. Pass Breakdown
+
+### Pass A: Move off Vercel runtime
+
+Scope:
+
+- add Graphile Worker
+- create worker process
+- replace `after()` with enqueue
+- add internal `stage` and retry/failure fields
+
+Success criteria:
+
+- summarize jobs run outside Vercel request lifecycle
+- retries are durable
+- provider errors are classified
+
+### Pass B: Move source extraction to worker tooling
+
+Scope:
+
+- replace primary media access path with `yt-dlp`
+- worker image includes `ffmpeg`
+- metadata/subtitle extraction runs in worker
+
+Success criteria:
+
+- current Vercel-side `429` path is no longer the main extraction route
+- stage transitions are visible
+
+### Pass C: Worker-side audio transcription
+
+Scope:
+
+- extract audio with `ffmpeg`
+- call OpenAI transcription
+- store transcript and evidence provenance
+
+Success criteria:
+
+- audio transcription no longer depends on Vercel function execution
+- jobs degrade gracefully when media is blocked
+
+### Pass D: Frame analysis (true Pass 2B)
+
+Scope:
+
+- frame sampling
+- vision analysis
+- evidence fusion upgrade
+
+Gate:
+
+- do not start until Pass C is stable enough to evaluate remaining failures
+
+## 12. Deployment Model
+
+Recommended deployment split:
+
+### App
+
+- Vercel
+- pooled Postgres runtime URL
+
+### Worker
+
+- separate service from the same repo
+- direct Postgres connection
+- Node 20+
+- `yt-dlp` and `ffmpeg` installed
+
+Important note:
+
+The worker should use a direct Postgres connection where durable workers and queue operations make sense.
+The web app can continue using the pooled connection strategy already set up for Vercel.
+
+## 13. Operations And Observability
+
+Required before broad rollout:
+
+1. structured logs by `jobId`
+2. `failureKind` classification
+3. attempt counts
+4. average duration by stage
+5. success rate by source type
+6. cache hit rate once caching exists
+
+Required QA dataset:
+
+- at least 25 representative YouTube Shorts
+- bucket outcomes into:
+  - good draft
+  - recoverable draft
+  - wrong draft
+  - insufficient context
+  - source blocked
+  - system failure
+
+## 14. Risks
+
+1. Source platform blocking will still exist
+- moving off Vercel improves the worker shape
+- it does not magically grant permanent extraction reliability
+
+2. This feature is infrastructure-heavy
+- if PantryClip keeps URL-to-draft as core, this is an intentional product investment
+
+3. Compliance and platform policy should be reviewed
+- PantryClip is depending on third-party media access as part of a core feature
+
+## 15. Recommendation
+
+Implement this in order:
+
+1. Move summarize execution off Vercel `after()`
+2. Add a dedicated worker with Postgres-backed queueing
+3. Move metadata/subtitle/media extraction into the worker
+4. Keep audio transcription in the worker
+5. Add frame analysis only after the worker-based extraction path is stable
+
+In short:
+
+Do not keep iterating on the current Vercel-bound extraction path.
+Build the ingestion layer that a signature URL-to-draft feature actually needs.

--- a/docs/pantryclip-v0-ui-prompt-v1.0.md
+++ b/docs/pantryclip-v0-ui-prompt-v1.0.md
@@ -1,0 +1,135 @@
+# PantryClip v0 UI Prompt v1.0
+
+Use this as a direct prompt in v0 to generate a mobile-first web app UI for PantryClip.
+
+---
+
+Design and generate a **mobile-first responsive web app UI** called **PantryClip**.
+
+## Product Context
+PantryClip helps users turn short-form recipe links (YouTube Shorts / Instagram Reels) into structured, searchable cooking notes.
+MVP flow: paste URL -> generate editable draft -> review/edit -> save -> search/reopen recipe.
+AI output is only a draft. User confirmation/edit is required before save.
+
+## UX Direction
+- Keep the interface clean, practical, and fast.
+- Prioritize readability while cooking.
+- One clear primary action per screen.
+- Minimize cognitive load and typing friction.
+- Avoid decorative complexity.
+
+## Visual Style
+- Tone: warm, minimal, kitchen-friendly, modern.
+- Use `tweakcn` theme: **Soft Pop**.
+- Use a light theme.
+- Use soft neutral background and one accent color for primary CTA.
+- Large readable typography for recipe content.
+- Comfortable spacing and touch targets (mobile-first).
+- Components should feel production-ready, not wireframe-like.
+
+## Technical Constraints
+- Generate using React + Tailwind + shadcn-style component patterns.
+- Apply `tweakcn` **Soft Pop** tokens/styles consistently across all screens and components.
+- Build responsive layouts with mobile as default and desktop as enhanced.
+- Include realistic empty/loading/error states.
+- No backend logic required; focus on UI structure and interactions.
+
+## Required Screens
+Create these screens and include navigation between them:
+
+1. **Auth Screen**
+- Minimal sign-in layout
+- App name + one-line value proposition
+- Email + password inputs
+- Primary CTA: Sign in
+- Secondary CTA: Create account
+
+2. **Recipe Home / List Screen**
+- Top bar with app name and Add Recipe button
+- Search input (placeholder: "Search recipes by title")
+- Recipe list cards (title, source type badge, updated date)
+- Empty state with CTA to add first recipe
+
+3. **Add Recipe Screen**
+- URL input field (YouTube Shorts / Instagram Reels)
+- Helper text with valid URL examples
+- Primary CTA: Generate with AI
+- Secondary action: Continue manually (skip AI)
+- Inline validation for invalid URL format
+
+4. **AI Draft Loading State**
+- Full-screen or centered loading state
+- Message: "Analyzing video and drafting recipe..."
+- Subtext that user can edit everything before saving
+- Optional cancel/back action
+
+5. **Review & Edit Draft Screen**
+- Editable fields:
+  - Title (single line)
+  - Ingredients (multiline)
+  - Steps (multiline)
+- Badge: "AI Draft"
+- Actions:
+  - Primary: Save Recipe
+  - Secondary: Regenerate Draft
+  - Tertiary: Back
+- Show inline validation if required fields are empty
+
+6. **Recipe Detail Screen**
+- Title
+- Source link + source type badge
+- Ingredients section
+- Steps section
+- Actions: Edit, Delete
+- Delete uses confirmation modal
+
+7. **Edit Recipe Screen**
+- Same form layout as Review screen
+- Primary CTA: Save Changes
+- Secondary action: Cancel
+
+## State Requirements
+Include UI for these states:
+- Empty recipe list
+- Search no results
+- AI generation error with actions:
+  - Retry generation
+  - Continue manual editing
+- Form validation errors
+- Delete confirmation modal
+- Success feedback (toast/snackbar) after save/update/delete
+
+## Information Architecture
+Use a simple app shell. Bottom nav is optional.
+If bottom nav is used, keep to:
+- Home
+- Add
+- Optional Settings placeholder
+
+## Interaction Rules
+- User can always continue manually if AI fails.
+- AI draft is never final until user taps Save.
+- Preserve user input when navigating back from validation errors.
+- Keep primary CTA sticky at bottom on mobile for long forms.
+- Search is title-based only in MVP.
+- Ensure edit and delete are available from detail screen.
+
+## Content and Copy
+Use realistic sample content in recipe cards and draft fields.
+Use concise, friendly microcopy.
+
+Suggested sample recipe titles:
+- "Spicy Tuna Mayo Rice Bowl"
+- "10-Minute Soy Butter Udon"
+- "Crispy Tofu Gochujang Stir-fry"
+
+## Accessibility Baseline
+- Proper labels for all inputs
+- Visible focus states
+- High contrast text/buttons
+- Tap targets >= 44px height on mobile
+
+## Output Request
+Generate all screens in a cohesive design system with reusable components.
+Prefer a single-page preview that can switch between screens using tabs/segments for quick review.
+Also provide a multi-page structure option if practical.

--- a/docs/sql/pantryclip-mvp-schema.sql
+++ b/docs/sql/pantryclip-mvp-schema.sql
@@ -1,0 +1,43 @@
+-- PantryClip MVP schema (PostgreSQL)
+
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'source_type') THEN
+    CREATE TYPE source_type AS ENUM ('youtube_shorts', 'instagram_reels', 'other');
+  END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'summary_source') THEN
+    CREATE TYPE summary_source AS ENUM ('manual', 'ai');
+  END IF;
+END $$;
+
+CREATE TABLE IF NOT EXISTS users (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  email TEXT NOT NULL UNIQUE,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS recipes (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  source_url TEXT NOT NULL,
+  source_type source_type NOT NULL,
+  title VARCHAR(140) NOT NULL,
+  ingredients_text TEXT NOT NULL,
+  steps_text TEXT NOT NULL,
+  summary_source summary_source NOT NULL,
+  ai_confidence DOUBLE PRECISION,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  CONSTRAINT recipes_ai_confidence_range
+    CHECK (ai_confidence IS NULL OR (ai_confidence >= 0 AND ai_confidence <= 1))
+);
+
+CREATE INDEX IF NOT EXISTS idx_recipes_user_created_id_desc
+  ON recipes (user_id, created_at DESC, id DESC);
+
+CREATE INDEX IF NOT EXISTS idx_recipes_user_lower_title
+  ON recipes (user_id, lower(title));

--- a/package.json
+++ b/package.json
@@ -13,6 +13,8 @@
     "format": "prettier . --write",
     "format:check": "prettier . --check",
     "typecheck": "tsc --noEmit",
+    "worker": "tsx src/worker/worker.ts",
+    "worker:migrate": "tsx src/worker/migrate.ts",
     "prisma:generate": "prisma generate",
     "prisma:migrate:dev": "prisma migrate dev",
     "prisma:studio": "prisma studio"
@@ -23,11 +25,13 @@
     "@prisma/client": "^6.5.0",
     "@supabase/ssr": "^0.7.0",
     "@supabase/supabase-js": "^2.49.4",
+    "graphile-worker": "^0.16.6",
     "next": "latest",
     "openai": "^6.32.0",
     "react": "latest",
     "react-dom": "latest",
     "swagger-ui-dist": "^5.32.0",
+    "tsx": "^4.21.0",
     "zod": "^3.23.8"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       '@supabase/supabase-js':
         specifier: ^2.49.4
         version: 2.99.1
+      graphile-worker:
+        specifier: ^0.16.6
+        version: 0.16.6(typescript@5.9.3)
       next:
         specifier: latest
         version: 16.1.6(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -38,6 +41,9 @@ importers:
       swagger-ui-dist:
         specifier: ^5.32.0
         version: 5.32.0
+      tsx:
+        specifier: ^4.21.0
+        version: 4.21.0
       zod:
         specifier: ^3.23.8
         version: 3.25.76
@@ -80,7 +86,7 @@ importers:
         version: 6.19.2(typescript@5.9.3)
       tailwindcss:
         specifier: ^3.4.17
-        version: 3.4.19(yaml@2.8.2)
+        version: 3.4.19(tsx@4.21.0)(yaml@2.8.2)
       typescript:
         specifier: ^5.7.2
         version: 5.9.3
@@ -176,6 +182,162 @@ packages:
   '@emnapi/wasi-threads@1.1.0':
     resolution: {integrity: sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ==}
 
+  '@esbuild/aix-ppc64@0.27.4':
+    resolution: {integrity: sha512-cQPwL2mp2nSmHHJlCyoXgHGhbEPMrEEU5xhkcy3Hs/O7nGZqEpZ2sUtLaL9MORLtDfRvVl2/3PAuEkYZH0Ty8Q==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.27.4':
+    resolution: {integrity: sha512-gdLscB7v75wRfu7QSm/zg6Rx29VLdy9eTr2t44sfTW7CxwAtQghZ4ZnqHk3/ogz7xao0QAgrkradbBzcqFPasw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.27.4':
+    resolution: {integrity: sha512-X9bUgvxiC8CHAGKYufLIHGXPJWnr0OCdR0anD2e21vdvgCI8lIfqFbnoeOz7lBjdrAGUhqLZLcQo6MLhTO2DKQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.27.4':
+    resolution: {integrity: sha512-PzPFnBNVF292sfpfhiyiXCGSn9HZg5BcAz+ivBuSsl6Rk4ga1oEXAamhOXRFyMcjwr2DVtm40G65N3GLeH1Lvw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.27.4':
+    resolution: {integrity: sha512-b7xaGIwdJlht8ZFCvMkpDN6uiSmnxxK56N2GDTMYPr2/gzvfdQN8rTfBsvVKmIVY/X7EM+/hJKEIbbHs9oA4tQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.27.4':
+    resolution: {integrity: sha512-sR+OiKLwd15nmCdqpXMnuJ9W2kpy0KigzqScqHI3Hqwr7IXxBp3Yva+yJwoqh7rE8V77tdoheRYataNKL4QrPw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.27.4':
+    resolution: {integrity: sha512-jnfpKe+p79tCnm4GVav68A7tUFeKQwQyLgESwEAUzyxk/TJr4QdGog9sqWNcUbr/bZt/O/HXouspuQDd9JxFSw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.27.4':
+    resolution: {integrity: sha512-2kb4ceA/CpfUrIcTUl1wrP/9ad9Atrp5J94Lq69w7UwOMolPIGrfLSvAKJp0RTvkPPyn6CIWrNy13kyLikZRZQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.27.4':
+    resolution: {integrity: sha512-7nQOttdzVGth1iz57kxg9uCz57dxQLHWxopL6mYuYthohPKEK0vU0C3O21CcBK6KDlkYVcnDXY099HcCDXd9dA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.27.4':
+    resolution: {integrity: sha512-aBYgcIxX/wd5n2ys0yESGeYMGF+pv6g0DhZr3G1ZG4jMfruU9Tl1i2Z+Wnj9/KjGz1lTLCcorqE2viePZqj4Eg==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.27.4':
+    resolution: {integrity: sha512-oPtixtAIzgvzYcKBQM/qZ3R+9TEUd1aNJQu0HhGyqtx6oS7qTpvjheIWBbes4+qu1bNlo2V4cbkISr8q6gRBFA==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.27.4':
+    resolution: {integrity: sha512-8mL/vh8qeCoRcFH2nM8wm5uJP+ZcVYGGayMavi8GmRJjuI3g1v6Z7Ni0JJKAJW+m0EtUuARb6Lmp4hMjzCBWzA==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.27.4':
+    resolution: {integrity: sha512-1RdrWFFiiLIW7LQq9Q2NES+HiD4NyT8Itj9AUeCl0IVCA459WnPhREKgwrpaIfTOe+/2rdntisegiPWn/r/aAw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.27.4':
+    resolution: {integrity: sha512-tLCwNG47l3sd9lpfyx9LAGEGItCUeRCWeAx6x2Jmbav65nAwoPXfewtAdtbtit/pJFLUWOhpv0FpS6GQAmPrHA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.27.4':
+    resolution: {integrity: sha512-BnASypppbUWyqjd1KIpU4AUBiIhVr6YlHx/cnPgqEkNoVOhHg+YiSVxM1RLfiy4t9cAulbRGTNCKOcqHrEQLIw==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.27.4':
+    resolution: {integrity: sha512-+eUqgb/Z7vxVLezG8bVB9SfBie89gMueS+I0xYh2tJdw3vqA/0ImZJ2ROeWwVJN59ihBeZ7Tu92dF/5dy5FttA==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.27.4':
+    resolution: {integrity: sha512-S5qOXrKV8BQEzJPVxAwnryi2+Iq5pB40gTEIT69BQONqR7JH1EPIcQ/Uiv9mCnn05jff9umq/5nqzxlqTOg9NA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.27.4':
+    resolution: {integrity: sha512-xHT8X4sb0GS8qTqiwzHqpY00C95DPAq7nAwX35Ie/s+LO9830hrMd3oX0ZMKLvy7vsonee73x0lmcdOVXFzd6Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.27.4':
+    resolution: {integrity: sha512-RugOvOdXfdyi5Tyv40kgQnI0byv66BFgAqjdgtAKqHoZTbTF2QqfQrFwa7cHEORJf6X2ht+l9ABLMP0dnKYsgg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.27.4':
+    resolution: {integrity: sha512-2MyL3IAaTX+1/qP0O1SwskwcwCoOI4kV2IBX1xYnDDqthmq5ArrW94qSIKCAuRraMgPOmG0RDTA74mzYNQA9ow==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.27.4':
+    resolution: {integrity: sha512-u8fg/jQ5aQDfsnIV6+KwLOf1CmJnfu1ShpwqdwC0uA7ZPwFws55Ngc12vBdeUdnuWoQYx/SOQLGDcdlfXhYmXQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.27.4':
+    resolution: {integrity: sha512-JkTZrl6VbyO8lDQO3yv26nNr2RM2yZzNrNHEsj9bm6dOwwu9OYN28CjzZkH57bh4w0I2F7IodpQvUAEd1mbWXg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.27.4':
+    resolution: {integrity: sha512-/gOzgaewZJfeJTlsWhvUEmUG4tWEY2Spp5M20INYRg2ZKl9QPO3QEEgPeRtLjEWSW8FilRNacPOg8R1uaYkA6g==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.27.4':
+    resolution: {integrity: sha512-Z9SExBg2y32smoDQdf1HRwHRt6vAHLXcxD2uGgO/v2jK7Y718Ix4ndsbNMU/+1Qiem9OiOdaqitioZwxivhXYg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.27.4':
+    resolution: {integrity: sha512-DAyGLS0Jz5G5iixEbMHi5KdiApqHBWMGzTtMiJ72ZOLhbu/bzxgAe8Ue8CTS3n3HbIUHQz/L51yMdGMeoxXNJw==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.27.4':
+    resolution: {integrity: sha512-+knoa0BDoeXgkNvvV1vvbZX4+hizelrkwmGJBdT17t8FNPwG2lKemmuMZlmaNQ3ws3DKKCxpb4zRZEIp3UxFCg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
   '@eslint-community/eslint-utils@4.9.1':
     resolution: {integrity: sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -213,6 +375,9 @@ packages:
   '@eslint/plugin-kit@0.4.1':
     resolution: {integrity: sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@graphile/logger@0.2.0':
+    resolution: {integrity: sha512-jjcWBokl9eb1gVJ85QmoaQ73CQ52xAaOCF29ukRbYNl6lY+ts0ErTaDYOBlejcbUs2OpaiqYLO5uDhyLFzWw4w==}
 
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
@@ -530,8 +695,14 @@ packages:
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
 
+  '@types/debug@4.1.13':
+    resolution: {integrity: sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==}
+
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
+  '@types/interpret@1.1.4':
+    resolution: {integrity: sha512-r+tPKWHYqaxJOYA3Eik0mMi+SEREqOXLmsooRFmc6GHv7nWUDixFtKN+cegvsPlDcEZd9wxsdp041v2imQuvag==}
 
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
@@ -539,8 +710,14 @@ packages:
   '@types/json5@0.0.29':
     resolution: {integrity: sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==}
 
+  '@types/ms@2.1.0':
+    resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
+
   '@types/node@22.19.13':
     resolution: {integrity: sha512-akNQMv0wW5uyRpD2v2IEyRSZiR+BeGuoB6L310EgGObO44HSMNT8z1xzio28V8qOrgYaopIDNA18YgdXd+qTiw==}
+
+  '@types/pg@8.20.0':
+    resolution: {integrity: sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow==}
 
   '@types/phoenix@1.6.7':
     resolution: {integrity: sha512-oN9ive//QSBkf19rfDv45M7eZPi0eEXylht2OLEXicu5b4KoQ1OzXIw+xDSGWxSxe1JmepRR/ZH283vsu518/Q==}
@@ -552,6 +729,9 @@ packages:
 
   '@types/react@19.2.14':
     resolution: {integrity: sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==}
+
+  '@types/semver@7.7.1':
+    resolution: {integrity: sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA==}
 
   '@types/ws@8.18.1':
     resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
@@ -727,6 +907,10 @@ packages:
   ajv@6.14.0:
     resolution: {integrity: sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==}
 
+  ansi-regex@5.0.1:
+    resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
+    engines: {node: '>=8'}
+
   ansi-styles@4.3.0:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
@@ -890,6 +1074,10 @@ packages:
   client-only@0.0.1:
     resolution: {integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==}
 
+  cliui@8.0.1:
+    resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
+    engines: {node: '>=12'}
+
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
     engines: {node: '>=7.0.0'}
@@ -917,6 +1105,15 @@ packages:
   cookie@1.1.1:
     resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
     engines: {node: '>=18'}
+
+  cosmiconfig@8.3.6:
+    resolution: {integrity: sha512-kcZ6+W5QzcJ3P1Mt+83OUv/oHFqZHIx8DuxG6eZ5RGMERoLqp4BuGjhHLYGK+Kf5XVkQvqBSmAy/nGWN3qDgEA==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      typescript: '>=4.9.5'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
@@ -1011,12 +1208,18 @@ packages:
   electron-to-chromium@1.5.307:
     resolution: {integrity: sha512-5z3uFKBWjiNR44nFcYdkcXjKMbg5KXNdciu7mhTPo9tB7NbqSNP2sSnGR+fqknZSCwKkBN+oxiiajWs4dT6ORg==}
 
+  emoji-regex@8.0.0:
+    resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
+
   emoji-regex@9.2.2:
     resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
 
   empathic@2.0.0:
     resolution: {integrity: sha512-i6UzDscO/XfAcNYD75CfICkmfLedpyPDdozrLMmQc5ORaQcdMoc21OnlEylMIqI7U8eniKrPMxxtj8k0vhmJhA==}
     engines: {node: '>=14'}
+
+  error-ex@1.3.4:
+    resolution: {integrity: sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==}
 
   es-abstract@1.24.1:
     resolution: {integrity: sha512-zHXBLhP+QehSSbsS9Pt23Gg964240DPd6QCf8WpkqEXxQ7fhdZzYsocOr5u7apWonsS5EjZDmTF+/slGMyasvw==}
@@ -1049,6 +1252,11 @@ packages:
   es-to-primitive@1.3.0:
     resolution: {integrity: sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==}
     engines: {node: '>= 0.4'}
+
+  esbuild@0.27.4:
+    resolution: {integrity: sha512-Rq4vbHnYkK5fws5NF7MYTU68FPRE1ajX7heQ/8QXXWqNgqqJ/GkmmyxIzUnf2Sr/bakf8l54716CcMGHYhMrrQ==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
@@ -1283,6 +1491,10 @@ packages:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
     engines: {node: '>=6.9.0'}
 
+  get-caller-file@2.0.5:
+    resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
+    engines: {node: 6.* || 8.* || >= 10.*}
+
   get-intrinsic@1.3.0:
     resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
     engines: {node: '>= 0.4'}
@@ -1325,6 +1537,15 @@ packages:
   gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
     engines: {node: '>= 0.4'}
+
+  graphile-config@0.0.1-beta.18:
+    resolution: {integrity: sha512-uMdF9Rt8/NwT1wVXNleYgM5ro2hHDodHiKA3efJhgdU8iP+r/hksnghOHreMva0sF5tV73f4TpiELPUR0g7O9w==}
+    engines: {node: '>=16'}
+
+  graphile-worker@0.16.6:
+    resolution: {integrity: sha512-e7gGYDmGqzju2l83MpzX8vNG/lOtVJiSzI3eZpAFubSxh/cxs7sRrRGBGjzBP1kNG0H+c95etPpNRNlH65PYhw==}
+    engines: {node: '>=14.0.0'}
+    hasBin: true
 
   has-bigints@1.1.0:
     resolution: {integrity: sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==}
@@ -1397,9 +1618,16 @@ packages:
     resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
     engines: {node: '>= 0.4'}
 
+  interpret@3.1.1:
+    resolution: {integrity: sha512-6xwYfHbajpoF0xLW+iwLkhwgvLoZDfjYfoFNu8ftMoXINzwuymNLd9u/KmwtdT2GbR+/Cz66otEGEVVUHX9QLQ==}
+    engines: {node: '>=10.13.0'}
+
   is-array-buffer@3.0.5:
     resolution: {integrity: sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==}
     engines: {node: '>= 0.4'}
+
+  is-arrayish@0.2.1:
+    resolution: {integrity: sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==}
 
   is-async-function@2.1.1:
     resolution: {integrity: sha512-9dgM/cZBnNvjzaMYHVoxxfPj2QXt22Ev7SuuPrs+xav0ukGB0S6d4ydZdEiM48kLx5kDV+QBPrpVnFyefL8kkQ==}
@@ -1443,6 +1671,10 @@ packages:
   is-finalizationregistry@1.1.1:
     resolution: {integrity: sha512-1pC6N8qWJbWoPtEjgcL2xyhQOP491EQjeUo3qTKcmV8YSDDJrOepfG8pcC7h/QgnQHYSv0mJ3Z/ZWxmatVrysg==}
     engines: {node: '>= 0.4'}
+
+  is-fullwidth-code-point@3.0.0:
+    resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
+    engines: {node: '>=8'}
 
   is-generator-function@1.1.2:
     resolution: {integrity: sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA==}
@@ -1536,6 +1768,9 @@ packages:
 
   json-buffer@3.0.1:
     resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
+
+  json-parse-even-better-errors@2.3.1:
+    resolution: {integrity: sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==}
 
   json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
@@ -1754,6 +1989,10 @@ packages:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
 
+  parse-json@5.2.0:
+    resolution: {integrity: sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==}
+    engines: {node: '>=8'}
+
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
@@ -1765,11 +2004,49 @@ packages:
   path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
 
+  path-type@4.0.0:
+    resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
+    engines: {node: '>=8'}
+
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
   perfect-debounce@1.0.0:
     resolution: {integrity: sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==}
+
+  pg-cloudflare@1.3.0:
+    resolution: {integrity: sha512-6lswVVSztmHiRtD6I8hw4qP/nDm1EJbKMRhf3HCYaqud7frGysPv7FYJ5noZQdhQtN2xJnimfMtvQq21pdbzyQ==}
+
+  pg-connection-string@2.12.0:
+    resolution: {integrity: sha512-U7qg+bpswf3Cs5xLzRqbXbQl85ng0mfSV/J0nnA31MCLgvEaAo7CIhmeyrmJpOr7o+zm0rXK+hNnT5l9RHkCkQ==}
+
+  pg-int8@1.0.1:
+    resolution: {integrity: sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==}
+    engines: {node: '>=4.0.0'}
+
+  pg-pool@3.13.0:
+    resolution: {integrity: sha512-gB+R+Xud1gLFuRD/QgOIgGOBE2KCQPaPwkzBBGC9oG69pHTkhQeIuejVIk3/cnDyX39av2AxomQiyPT13WKHQA==}
+    peerDependencies:
+      pg: '>=8.0'
+
+  pg-protocol@1.13.0:
+    resolution: {integrity: sha512-zzdvXfS6v89r6v7OcFCHfHlyG/wvry1ALxZo4LqgUoy7W9xhBDMaqOuMiF3qEV45VqsN6rdlcehHrfDtlCPc8w==}
+
+  pg-types@2.2.0:
+    resolution: {integrity: sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==}
+    engines: {node: '>=4'}
+
+  pg@8.20.0:
+    resolution: {integrity: sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==}
+    engines: {node: '>= 16.0.0'}
+    peerDependencies:
+      pg-native: '>=3.0.1'
+    peerDependenciesMeta:
+      pg-native:
+        optional: true
+
+  pgpass@1.0.5:
+    resolution: {integrity: sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==}
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
@@ -1848,6 +2125,22 @@ packages:
     resolution: {integrity: sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==}
     engines: {node: ^10 || ^12 || >=14}
 
+  postgres-array@2.0.0:
+    resolution: {integrity: sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==}
+    engines: {node: '>=4'}
+
+  postgres-bytea@1.0.1:
+    resolution: {integrity: sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==}
+    engines: {node: '>=0.10.0'}
+
+  postgres-date@1.0.7:
+    resolution: {integrity: sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==}
+    engines: {node: '>=0.10.0'}
+
+  postgres-interval@1.2.0:
+    resolution: {integrity: sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==}
+    engines: {node: '>=0.10.0'}
+
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
@@ -1913,6 +2206,10 @@ packages:
   regexp.prototype.flags@1.5.4:
     resolution: {integrity: sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==}
     engines: {node: '>= 0.4'}
+
+  require-directory@2.1.1:
+    resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
+    engines: {node: '>=0.10.0'}
 
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
@@ -2010,12 +2307,20 @@ packages:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
 
+  split2@4.2.0:
+    resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
+    engines: {node: '>= 10.x'}
+
   stable-hash@0.0.5:
     resolution: {integrity: sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==}
 
   stop-iteration-iterator@1.1.0:
     resolution: {integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==}
     engines: {node: '>= 0.4'}
+
+  string-width@4.2.3:
+    resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
+    engines: {node: '>=8'}
 
   string.prototype.includes@2.0.1:
     resolution: {integrity: sha512-o7+c9bW6zpAdJHTtujeePODAhkuicdAryFsfVKwA+wGw89wJ4GTY484WTucM9hLtDEOpOvI+aHnzqnC5lHp4Rg==}
@@ -2039,6 +2344,10 @@ packages:
   string.prototype.trimstart@1.0.8:
     resolution: {integrity: sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg==}
     engines: {node: '>= 0.4'}
+
+  strip-ansi@6.0.1:
+    resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
+    engines: {node: '>=8'}
 
   strip-bom@3.0.0:
     resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
@@ -2127,6 +2436,11 @@ packages:
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
+  tsx@4.21.0:
+    resolution: {integrity: sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
@@ -2210,6 +2524,10 @@ packages:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
 
+  wrap-ansi@7.0.0:
+    resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
+    engines: {node: '>=10'}
+
   ws@8.19.0:
     resolution: {integrity: sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==}
     engines: {node: '>=10.0.0'}
@@ -2222,6 +2540,14 @@ packages:
       utf-8-validate:
         optional: true
 
+  xtend@4.0.2:
+    resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
+    engines: {node: '>=0.4'}
+
+  y18n@5.0.8:
+    resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
+    engines: {node: '>=10'}
+
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
 
@@ -2229,6 +2555,14 @@ packages:
     resolution: {integrity: sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==}
     engines: {node: '>= 14.6'}
     hasBin: true
+
+  yargs-parser@21.1.1:
+    resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
+    engines: {node: '>=12'}
+
+  yargs@17.7.2:
+    resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
+    engines: {node: '>=12'}
 
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
@@ -2380,6 +2714,84 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@esbuild/aix-ppc64@0.27.4':
+    optional: true
+
+  '@esbuild/android-arm64@0.27.4':
+    optional: true
+
+  '@esbuild/android-arm@0.27.4':
+    optional: true
+
+  '@esbuild/android-x64@0.27.4':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.27.4':
+    optional: true
+
+  '@esbuild/darwin-x64@0.27.4':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.27.4':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.27.4':
+    optional: true
+
+  '@esbuild/linux-arm64@0.27.4':
+    optional: true
+
+  '@esbuild/linux-arm@0.27.4':
+    optional: true
+
+  '@esbuild/linux-ia32@0.27.4':
+    optional: true
+
+  '@esbuild/linux-loong64@0.27.4':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.27.4':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.27.4':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.27.4':
+    optional: true
+
+  '@esbuild/linux-s390x@0.27.4':
+    optional: true
+
+  '@esbuild/linux-x64@0.27.4':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.27.4':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.27.4':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.27.4':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.27.4':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.27.4':
+    optional: true
+
+  '@esbuild/sunos-x64@0.27.4':
+    optional: true
+
+  '@esbuild/win32-arm64@0.27.4':
+    optional: true
+
+  '@esbuild/win32-ia32@0.27.4':
+    optional: true
+
+  '@esbuild/win32-x64@0.27.4':
+    optional: true
+
   '@eslint-community/eslint-utils@4.9.1(eslint@9.39.3(jiti@1.21.7))':
     dependencies:
       eslint: 9.39.3(jiti@1.21.7)
@@ -2425,6 +2837,8 @@ snapshots:
     dependencies:
       '@eslint/core': 0.17.0
       levn: 0.4.1
+
+  '@graphile/logger@0.2.0': {}
 
   '@humanfs/core@0.19.1': {}
 
@@ -2697,15 +3111,31 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@types/debug@4.1.13':
+    dependencies:
+      '@types/ms': 2.1.0
+
   '@types/estree@1.0.8': {}
+
+  '@types/interpret@1.1.4':
+    dependencies:
+      '@types/node': 22.19.13
 
   '@types/json-schema@7.0.15': {}
 
   '@types/json5@0.0.29': {}
 
+  '@types/ms@2.1.0': {}
+
   '@types/node@22.19.13':
     dependencies:
       undici-types: 6.21.0
+
+  '@types/pg@8.20.0':
+    dependencies:
+      '@types/node': 22.19.13
+      pg-protocol: 1.13.0
+      pg-types: 2.2.0
 
   '@types/phoenix@1.6.7': {}
 
@@ -2716,6 +3146,8 @@ snapshots:
   '@types/react@19.2.14':
     dependencies:
       csstype: 3.2.3
+
+  '@types/semver@7.7.1': {}
 
   '@types/ws@8.18.1':
     dependencies:
@@ -2885,6 +3317,8 @@ snapshots:
       fast-json-stable-stringify: 2.1.0
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
+
+  ansi-regex@5.0.1: {}
 
   ansi-styles@4.3.0:
     dependencies:
@@ -3087,6 +3521,12 @@ snapshots:
 
   client-only@0.0.1: {}
 
+  cliui@8.0.1:
+    dependencies:
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+      wrap-ansi: 7.0.0
+
   color-convert@2.0.1:
     dependencies:
       color-name: 1.1.4
@@ -3104,6 +3544,15 @@ snapshots:
   convert-source-map@2.0.0: {}
 
   cookie@1.1.1: {}
+
+  cosmiconfig@8.3.6(typescript@5.9.3):
+    dependencies:
+      import-fresh: 3.3.1
+      js-yaml: 4.1.1
+      parse-json: 5.2.0
+      path-type: 4.0.0
+    optionalDependencies:
+      typescript: 5.9.3
 
   cross-spawn@7.0.6:
     dependencies:
@@ -3189,9 +3638,15 @@ snapshots:
 
   electron-to-chromium@1.5.307: {}
 
+  emoji-regex@8.0.0: {}
+
   emoji-regex@9.2.2: {}
 
   empathic@2.0.0: {}
+
+  error-ex@1.3.4:
+    dependencies:
+      is-arrayish: 0.2.1
 
   es-abstract@1.24.1:
     dependencies:
@@ -3293,6 +3748,35 @@ snapshots:
       is-callable: 1.2.7
       is-date-object: 1.1.0
       is-symbol: 1.1.1
+
+  esbuild@0.27.4:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.27.4
+      '@esbuild/android-arm': 0.27.4
+      '@esbuild/android-arm64': 0.27.4
+      '@esbuild/android-x64': 0.27.4
+      '@esbuild/darwin-arm64': 0.27.4
+      '@esbuild/darwin-x64': 0.27.4
+      '@esbuild/freebsd-arm64': 0.27.4
+      '@esbuild/freebsd-x64': 0.27.4
+      '@esbuild/linux-arm': 0.27.4
+      '@esbuild/linux-arm64': 0.27.4
+      '@esbuild/linux-ia32': 0.27.4
+      '@esbuild/linux-loong64': 0.27.4
+      '@esbuild/linux-mips64el': 0.27.4
+      '@esbuild/linux-ppc64': 0.27.4
+      '@esbuild/linux-riscv64': 0.27.4
+      '@esbuild/linux-s390x': 0.27.4
+      '@esbuild/linux-x64': 0.27.4
+      '@esbuild/netbsd-arm64': 0.27.4
+      '@esbuild/netbsd-x64': 0.27.4
+      '@esbuild/openbsd-arm64': 0.27.4
+      '@esbuild/openbsd-x64': 0.27.4
+      '@esbuild/openharmony-arm64': 0.27.4
+      '@esbuild/sunos-x64': 0.27.4
+      '@esbuild/win32-arm64': 0.27.4
+      '@esbuild/win32-ia32': 0.27.4
+      '@esbuild/win32-x64': 0.27.4
 
   escalade@3.2.0: {}
 
@@ -3599,6 +4083,8 @@ snapshots:
 
   gensync@1.0.0-beta.2: {}
 
+  get-caller-file@2.0.5: {}
+
   get-intrinsic@1.3.0:
     dependencies:
       call-bind-apply-helpers: 1.0.2
@@ -3654,6 +4140,36 @@ snapshots:
       gopd: 1.2.0
 
   gopd@1.2.0: {}
+
+  graphile-config@0.0.1-beta.18:
+    dependencies:
+      '@types/interpret': 1.1.4
+      '@types/node': 22.19.13
+      '@types/semver': 7.7.1
+      chalk: 4.1.2
+      debug: 4.4.3
+      interpret: 3.1.1
+      semver: 7.7.4
+      tslib: 2.8.1
+      yargs: 17.7.2
+    transitivePeerDependencies:
+      - supports-color
+
+  graphile-worker@0.16.6(typescript@5.9.3):
+    dependencies:
+      '@graphile/logger': 0.2.0
+      '@types/debug': 4.1.13
+      '@types/pg': 8.20.0
+      cosmiconfig: 8.3.6(typescript@5.9.3)
+      graphile-config: 0.0.1-beta.18
+      json5: 2.2.3
+      pg: 8.20.0
+      tslib: 2.8.1
+      yargs: 17.7.2
+    transitivePeerDependencies:
+      - pg-native
+      - supports-color
+      - typescript
 
   has-bigints@1.1.0: {}
 
@@ -3716,11 +4232,15 @@ snapshots:
       hasown: 2.0.2
       side-channel: 1.1.0
 
+  interpret@3.1.1: {}
+
   is-array-buffer@3.0.5:
     dependencies:
       call-bind: 1.0.8
       call-bound: 1.0.4
       get-intrinsic: 1.3.0
+
+  is-arrayish@0.2.1: {}
 
   is-async-function@2.1.1:
     dependencies:
@@ -3769,6 +4289,8 @@ snapshots:
   is-finalizationregistry@1.1.1:
     dependencies:
       call-bound: 1.0.4
+
+  is-fullwidth-code-point@3.0.0: {}
 
   is-generator-function@1.1.2:
     dependencies:
@@ -3858,6 +4380,8 @@ snapshots:
   jsesc@3.1.0: {}
 
   json-buffer@3.0.1: {}
+
+  json-parse-even-better-errors@2.3.1: {}
 
   json-schema-traverse@0.4.1: {}
 
@@ -4074,15 +4598,59 @@ snapshots:
     dependencies:
       callsites: 3.1.0
 
+  parse-json@5.2.0:
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      error-ex: 1.3.4
+      json-parse-even-better-errors: 2.3.1
+      lines-and-columns: 1.2.4
+
   path-exists@4.0.0: {}
 
   path-key@3.1.1: {}
 
   path-parse@1.0.7: {}
 
+  path-type@4.0.0: {}
+
   pathe@2.0.3: {}
 
   perfect-debounce@1.0.0: {}
+
+  pg-cloudflare@1.3.0:
+    optional: true
+
+  pg-connection-string@2.12.0: {}
+
+  pg-int8@1.0.1: {}
+
+  pg-pool@3.13.0(pg@8.20.0):
+    dependencies:
+      pg: 8.20.0
+
+  pg-protocol@1.13.0: {}
+
+  pg-types@2.2.0:
+    dependencies:
+      pg-int8: 1.0.1
+      postgres-array: 2.0.0
+      postgres-bytea: 1.0.1
+      postgres-date: 1.0.7
+      postgres-interval: 1.2.0
+
+  pg@8.20.0:
+    dependencies:
+      pg-connection-string: 2.12.0
+      pg-pool: 3.13.0(pg@8.20.0)
+      pg-protocol: 1.13.0
+      pg-types: 2.2.0
+      pgpass: 1.0.5
+    optionalDependencies:
+      pg-cloudflare: 1.3.0
+
+  pgpass@1.0.5:
+    dependencies:
+      split2: 4.2.0
 
   picocolors@1.1.1: {}
 
@@ -4114,12 +4682,13 @@ snapshots:
       camelcase-css: 2.0.1
       postcss: 8.5.8
 
-  postcss-load-config@6.0.1(jiti@1.21.7)(postcss@8.5.8)(yaml@2.8.2):
+  postcss-load-config@6.0.1(jiti@1.21.7)(postcss@8.5.8)(tsx@4.21.0)(yaml@2.8.2):
     dependencies:
       lilconfig: 3.1.3
     optionalDependencies:
       jiti: 1.21.7
       postcss: 8.5.8
+      tsx: 4.21.0
       yaml: 2.8.2
 
   postcss-nested@6.2.0(postcss@8.5.8):
@@ -4145,6 +4714,16 @@ snapshots:
       nanoid: 3.3.11
       picocolors: 1.1.1
       source-map-js: 1.2.1
+
+  postgres-array@2.0.0: {}
+
+  postgres-bytea@1.0.1: {}
+
+  postgres-date@1.0.7: {}
+
+  postgres-interval@1.2.0:
+    dependencies:
+      xtend: 4.0.2
 
   prelude-ls@1.2.1: {}
 
@@ -4214,6 +4793,8 @@ snapshots:
       get-proto: 1.0.1
       gopd: 1.2.0
       set-function-name: 2.0.2
+
+  require-directory@2.1.1: {}
 
   resolve-from@4.0.0: {}
 
@@ -4357,12 +4938,20 @@ snapshots:
 
   source-map-js@1.2.1: {}
 
+  split2@4.2.0: {}
+
   stable-hash@0.0.5: {}
 
   stop-iteration-iterator@1.1.0:
     dependencies:
       es-errors: 1.3.0
       internal-slot: 1.1.0
+
+  string-width@4.2.3:
+    dependencies:
+      emoji-regex: 8.0.0
+      is-fullwidth-code-point: 3.0.0
+      strip-ansi: 6.0.1
 
   string.prototype.includes@2.0.1:
     dependencies:
@@ -4414,6 +5003,10 @@ snapshots:
       define-properties: 1.2.1
       es-object-atoms: 1.1.1
 
+  strip-ansi@6.0.1:
+    dependencies:
+      ansi-regex: 5.0.1
+
   strip-bom@3.0.0: {}
 
   strip-json-comments@3.1.1: {}
@@ -4445,7 +5038,7 @@ snapshots:
     dependencies:
       '@scarf/scarf': 1.4.0
 
-  tailwindcss@3.4.19(yaml@2.8.2):
+  tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.2):
     dependencies:
       '@alloc/quick-lru': 5.2.0
       arg: 5.0.2
@@ -4464,7 +5057,7 @@ snapshots:
       postcss: 8.5.8
       postcss-import: 15.1.0(postcss@8.5.8)
       postcss-js: 4.1.0(postcss@8.5.8)
-      postcss-load-config: 6.0.1(jiti@1.21.7)(postcss@8.5.8)(yaml@2.8.2)
+      postcss-load-config: 6.0.1(jiti@1.21.7)(postcss@8.5.8)(tsx@4.21.0)(yaml@2.8.2)
       postcss-nested: 6.2.0(postcss@8.5.8)
       postcss-selector-parser: 6.1.2
       resolve: 1.22.11
@@ -4516,6 +5109,13 @@ snapshots:
       strip-bom: 3.0.0
 
   tslib@2.8.1: {}
+
+  tsx@4.21.0:
+    dependencies:
+      esbuild: 0.27.4
+      get-tsconfig: 4.13.6
+    optionalDependencies:
+      fsevents: 2.3.3
 
   type-check@0.4.0:
     dependencies:
@@ -4661,11 +5261,33 @@ snapshots:
 
   word-wrap@1.2.5: {}
 
+  wrap-ansi@7.0.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+
   ws@8.19.0: {}
+
+  xtend@4.0.2: {}
+
+  y18n@5.0.8: {}
 
   yallist@3.1.1: {}
 
   yaml@2.8.2: {}
+
+  yargs-parser@21.1.1: {}
+
+  yargs@17.7.2:
+    dependencies:
+      cliui: 8.0.1
+      escalade: 3.2.0
+      get-caller-file: 2.0.5
+      require-directory: 2.1.1
+      string-width: 4.2.3
+      y18n: 5.0.8
+      yargs-parser: 21.1.1
 
   yocto-queue@0.1.0: {}
 

--- a/prisma/migrations/20260330195000_add_summarize_job_stage_fields/migration.sql
+++ b/prisma/migrations/20260330195000_add_summarize_job_stage_fields/migration.sql
@@ -1,0 +1,32 @@
+CREATE TYPE "summarize_job_stage" AS ENUM (
+  'queued',
+  'extracting_metadata',
+  'extracting_subtitles',
+  'downloading_media',
+  'transcribing_audio',
+  'extracting_frames',
+  'analyzing_frames',
+  'summarizing',
+  'completed',
+  'insufficient_context',
+  'failed'
+);
+
+CREATE TYPE "summarize_job_failure_kind" AS ENUM (
+  'source_rate_limited',
+  'source_unavailable',
+  'media_download_failed',
+  'transcription_failed',
+  'vision_failed',
+  'insufficient_context',
+  'internal_error'
+);
+
+ALTER TABLE "summarize_jobs"
+  ADD COLUMN "stage" "summarize_job_stage" NOT NULL DEFAULT 'queued',
+  ADD COLUMN "attempt_count" INTEGER NOT NULL DEFAULT 0,
+  ADD COLUMN "last_attempt_at" TIMESTAMPTZ(6),
+  ADD COLUMN "provider_code" TEXT,
+  ADD COLUMN "provider_message" TEXT,
+  ADD COLUMN "failure_kind" "summarize_job_failure_kind",
+  ADD COLUMN "media_debug" JSONB;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -33,6 +33,34 @@ enum SummarizeJobStatus {
   @@map("summarize_job_status")
 }
 
+enum SummarizeJobStage {
+  queued
+  extracting_metadata
+  extracting_subtitles
+  downloading_media
+  transcribing_audio
+  extracting_frames
+  analyzing_frames
+  summarizing
+  completed
+  insufficient_context
+  failed
+
+  @@map("summarize_job_stage")
+}
+
+enum SummarizeJobFailureKind {
+  source_rate_limited
+  source_unavailable
+  media_download_failed
+  transcription_failed
+  vision_failed
+  insufficient_context
+  internal_error
+
+  @@map("summarize_job_failure_kind")
+}
+
 model User {
   id            String         @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
   email         String         @unique
@@ -70,12 +98,19 @@ model SummarizeJob {
   sourceUrl        String             @map("source_url")
   sourceType       SourceType         @map("source_type")
   status           SummarizeJobStatus
+  stage            SummarizeJobStage  @default(queued)
   canonicalVideoId String?            @map("canonical_video_id")
   titleHint        String?            @map("title_hint")
   descriptionHint  String?            @map("description_hint")
   subtitleText     String?            @map("subtitle_text")
   transcriptText   String?            @map("transcript_text")
   evidenceSources  Json?              @map("evidence_sources")
+  attemptCount     Int                @default(0) @map("attempt_count")
+  lastAttemptAt    DateTime?          @map("last_attempt_at") @db.Timestamptz(6)
+  providerCode     String?            @map("provider_code")
+  providerMessage  String?            @map("provider_message")
+  failureKind      SummarizeJobFailureKind? @map("failure_kind")
+  mediaDebug       Json?              @map("media_debug")
   confidence       Float?             @map("confidence")
   draftPayload     Json?              @map("draft_payload")
   errorCode        String?            @map("error_code")

--- a/src/app/api/recipes/summarize/route.ts
+++ b/src/app/api/recipes/summarize/route.ts
@@ -1,10 +1,13 @@
-import { after, NextRequest, NextResponse } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
 
 import { summarizeRecipeSchema } from "@/src/apps/recipes/recipes.schemas";
 import { requireUserId } from "@/src/lib/auth/require-user-id";
-import { runSummarizeJob } from "@/src/lib/server/recipes/recipes-summarize-job-runner";
-import { createSummarizeJob } from "@/src/lib/server/recipes/recipes-summarize-jobs.repository";
-import { toErrorResponse } from "@/src/lib/utils/api-error";
+import {
+  createSummarizeJob,
+  markSummarizeJobFailed
+} from "@/src/lib/server/recipes/recipes-summarize-jobs.repository";
+import { enqueueSummarizeJob } from "@/src/lib/server/recipes/recipes-summarize-queue.service";
+import { ApiError, toErrorResponse } from "@/src/lib/utils/api-error";
 
 export async function POST(request: NextRequest) {
   try {
@@ -13,13 +16,22 @@ export async function POST(request: NextRequest) {
     const input = summarizeRecipeSchema.parse(json);
     const job = await createSummarizeJob(userId, input);
 
-    after(async () => {
-      try {
-        await runSummarizeJob(job.jobId);
-      } catch (error) {
-        console.error("Failed to run summarize job", { jobId: job.jobId, error });
-      }
-    });
+    try {
+      await enqueueSummarizeJob(job.jobId);
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : "Failed to enqueue summarize job";
+
+      await markSummarizeJobFailed(job.jobId, "QUEUE_ENQUEUE_FAILED", message, {
+        failureKind: "internal_error"
+      });
+
+      throw new ApiError(
+        "INTERNAL_ERROR",
+        "AI 초안 작업을 시작하지 못했습니다. 잠시 후 다시 시도해주세요.",
+        500
+      );
+    }
 
     return NextResponse.json(job, { status: 202 });
   } catch (error) {

--- a/src/lib/server/recipes/recipes-extraction.service.ts
+++ b/src/lib/server/recipes/recipes-extraction.service.ts
@@ -1,7 +1,11 @@
 import type { SourceType, SummarizeRecipeInput } from "@/src/apps/recipes/recipes.types";
 import { inferSourceType } from "@/src/lib/server/recipes/recipes.utils";
+import type { SummarizeJobStage } from "@/src/lib/server/recipes/recipes-summarize-jobs.types";
 import { transcribeRecipeAudio } from "@/src/lib/server/recipes/recipes-transcription.service";
-import { downloadYouTubeRecipeAudio } from "@/src/lib/server/recipes/recipes-youtube-audio.service";
+import {
+  downloadYouTubeRecipeAudio,
+  type RecipeAudioDownloadIssue
+} from "@/src/lib/server/recipes/recipes-youtube-audio.service";
 
 const MIN_RECIPE_NARRATIVE_LENGTH = 120;
 
@@ -31,6 +35,18 @@ export type ExtractedRecipeContext = {
   subtitleText: string;
   transcriptText: string;
   evidenceSources: string[];
+  extractionIssue: RecipeExtractionIssue | null;
+};
+
+type ExtractRecipeContextOptions = {
+  onStageChange?: (stage: SummarizeJobStage) => Promise<void> | void;
+};
+
+export type RecipeExtractionIssue = {
+  failureKind: RecipeAudioDownloadIssue["failureKind"];
+  providerCode: string;
+  providerMessage: string;
+  mediaDebug?: Record<string, unknown>;
 };
 
 function emptyRecipeContext(
@@ -44,7 +60,8 @@ function emptyRecipeContext(
     description: "",
     subtitleText: "",
     transcriptText: "",
-    evidenceSources: []
+    evidenceSources: [],
+    extractionIssue: null
   };
 }
 
@@ -199,12 +216,16 @@ function pickCaptionTrack(playerResponse: YouTubePlayerResponse | null): string 
   return preferredTrack?.baseUrl ?? null;
 }
 
-async function fetchYouTubeTranscript(baseUrl: string | null): Promise<string> {
+async function fetchYouTubeTranscript(
+  baseUrl: string | null,
+  options: ExtractRecipeContextOptions
+): Promise<string> {
   if (!baseUrl) {
     return "";
   }
 
   try {
+    await options.onStageChange?.("extracting_subtitles");
     const transcriptXml = await fetchText(baseUrl);
     const lines = Array.from(transcriptXml.matchAll(/<text[^>]*>([\s\S]*?)<\/text>/g)).map(
       (match) => normalizeWhitespace(match[1] ?? "")
@@ -217,30 +238,61 @@ async function fetchYouTubeTranscript(baseUrl: string | null): Promise<string> {
 }
 
 async function maybeTranscribeYouTubeAudio(
-  context: Pick<ExtractedRecipeContext, "canonicalVideoId" | "title" | "description" | "subtitleText">
-): Promise<string> {
+  context: Pick<ExtractedRecipeContext, "canonicalVideoId" | "title" | "description" | "subtitleText">,
+  options: ExtractRecipeContextOptions
+): Promise<{
+  transcriptText: string;
+  extractionIssue: RecipeExtractionIssue | null;
+}> {
   if (!context.canonicalVideoId || context.subtitleText.length >= MIN_RECIPE_NARRATIVE_LENGTH) {
-    return "";
+    return {
+      transcriptText: "",
+      extractionIssue: null
+    };
   }
 
-  const audio = await downloadYouTubeRecipeAudio(context.canonicalVideoId);
+  await options.onStageChange?.("downloading_media");
+  const { audio, issue } = await downloadYouTubeRecipeAudio(context.canonicalVideoId);
 
   if (!audio) {
-    return "";
+    return {
+      transcriptText: "",
+      extractionIssue: issue
+    };
   }
 
   try {
-    return await transcribeRecipeAudio(audio, {
-      title: context.title,
-      description: context.description
-    });
+    await options.onStageChange?.("transcribing_audio");
+    return {
+      transcriptText: await transcribeRecipeAudio(audio, {
+        title: context.title,
+        description: context.description
+      }),
+      extractionIssue: null
+    };
   } catch (error) {
     console.error("Recipe audio transcription failed", error);
-    return "";
+
+    return {
+      transcriptText: "",
+      extractionIssue: {
+        failureKind: "transcription_failed",
+        providerCode: "OPENAI_TRANSCRIPTION_FAILED",
+        providerMessage:
+          error instanceof Error ? error.message : "Audio transcription failed.",
+        mediaDebug: {
+          canonicalVideoId: context.canonicalVideoId,
+          model: process.env.OPENAI_TRANSCRIPTION_MODEL ?? "gpt-4o-transcribe"
+        }
+      }
+    };
   }
 }
 
-async function fetchYouTubeContext(sourceUrl: string): Promise<ExtractedRecipeContext> {
+async function fetchYouTubeContext(
+  sourceUrl: string,
+  options: ExtractRecipeContextOptions
+): Promise<ExtractedRecipeContext> {
   const videoId = extractYouTubeVideoId(sourceUrl);
 
   if (!videoId) {
@@ -250,21 +302,28 @@ async function fetchYouTubeContext(sourceUrl: string): Promise<ExtractedRecipeCo
   const canonicalUrl = `https://www.youtube.com/watch?v=${videoId}&hl=ko`;
 
   try {
+    await options.onStageChange?.("extracting_metadata");
     const html = await fetchText(canonicalUrl);
     const playerResponse = extractJsonAssignment(
       html,
       "var ytInitialPlayerResponse = "
     ) as YouTubePlayerResponse | null;
     const videoDetails = playerResponse?.videoDetails;
-    const subtitleText = await fetchYouTubeTranscript(pickCaptionTrack(playerResponse));
+    const subtitleText = await fetchYouTubeTranscript(
+      pickCaptionTrack(playerResponse),
+      options
+    );
     const title = normalizeWhitespace(videoDetails?.title ?? "");
     const description = normalizeWhitespace(videoDetails?.shortDescription ?? "");
-    const transcriptText = await maybeTranscribeYouTubeAudio({
-      canonicalVideoId: videoId,
-      title,
-      description,
-      subtitleText
-    });
+    const { transcriptText, extractionIssue } = await maybeTranscribeYouTubeAudio(
+      {
+        canonicalVideoId: videoId,
+        title,
+        description,
+        subtitleText
+      },
+      options
+    );
     const evidenceSources: string[] = [];
 
     if (title || description) {
@@ -286,28 +345,32 @@ async function fetchYouTubeContext(sourceUrl: string): Promise<ExtractedRecipeCo
       description,
       subtitleText,
       transcriptText,
-      evidenceSources
+      evidenceSources,
+      extractionIssue
     };
   } catch {
-    const transcriptText = await maybeTranscribeYouTubeAudio(
-      emptyRecipeContext("youtube_shorts", videoId)
+    const { transcriptText, extractionIssue } = await maybeTranscribeYouTubeAudio(
+      emptyRecipeContext("youtube_shorts", videoId),
+      options
     );
 
     return {
       ...emptyRecipeContext("youtube_shorts", videoId),
       transcriptText,
-      evidenceSources: transcriptText ? ["openai_audio_transcription"] : []
+      evidenceSources: transcriptText ? ["openai_audio_transcription"] : [],
+      extractionIssue
     };
   }
 }
 
 export async function extractRecipeContext(
-  input: SummarizeRecipeInput
+  input: SummarizeRecipeInput,
+  options: ExtractRecipeContextOptions = {}
 ): Promise<ExtractedRecipeContext> {
   const sourceType = inferSourceType(input.sourceUrl);
 
   if (sourceType === "youtube_shorts") {
-    const youtubeContext = await fetchYouTubeContext(input.sourceUrl);
+    const youtubeContext = await fetchYouTubeContext(input.sourceUrl, options);
 
     if (
       youtubeContext.title ||
@@ -317,8 +380,19 @@ export async function extractRecipeContext(
     ) {
       return youtubeContext;
     }
-  }
 
+    const meta = await fetchPageMeta(input.sourceUrl);
+
+    return {
+      ...youtubeContext,
+      title: meta.title,
+      description: meta.description,
+      evidenceSources: [
+        ...youtubeContext.evidenceSources,
+        ...(meta.title || meta.description ? ["page_meta"] : [])
+      ]
+    };
+  }
   const meta = await fetchPageMeta(input.sourceUrl);
 
   return {
@@ -328,7 +402,8 @@ export async function extractRecipeContext(
     description: meta.description,
     subtitleText: "",
     transcriptText: "",
-    evidenceSources: meta.title || meta.description ? ["page_meta"] : []
+    evidenceSources: meta.title || meta.description ? ["page_meta"] : [],
+    extractionIssue: null
   };
 }
 

--- a/src/lib/server/recipes/recipes-summarize-job-runner.ts
+++ b/src/lib/server/recipes/recipes-summarize-job-runner.ts
@@ -10,6 +10,7 @@ import {
   markSummarizeJobFailed,
   markSummarizeJobInsufficientContext,
   markSummarizeJobSummarizing,
+  setSummarizeJobStage,
   storeSummarizeJobEvidence
 } from "@/src/lib/server/recipes/recipes-summarize-jobs.repository";
 import { summarizeRecipeFromContext } from "@/src/lib/server/recipes/recipes-summarizer.service";
@@ -26,7 +27,14 @@ export async function runSummarizeJob(jobId: string): Promise<void> {
   let context: ExtractedRecipeContext | null = null;
 
   try {
-    context = await extractRecipeContext({ sourceUrl: job.sourceUrl });
+    context = await extractRecipeContext(
+      { sourceUrl: job.sourceUrl },
+      {
+        onStageChange: async (stage) => {
+          await setSummarizeJobStage(jobId, stage);
+        }
+      }
+    );
 
     await storeSummarizeJobEvidence(jobId, context);
 
@@ -56,6 +64,8 @@ export async function runSummarizeJob(jobId: string): Promise<void> {
     const message =
       error instanceof Error ? error.message : "Unexpected summarize job failure";
 
-    await markSummarizeJobFailed(jobId, "SUMMARIZE_FAILED", message);
+    await markSummarizeJobFailed(jobId, "SUMMARIZE_FAILED", message, {
+      failureKind: "internal_error"
+    });
   }
 }

--- a/src/lib/server/recipes/recipes-summarize-jobs.repository.ts
+++ b/src/lib/server/recipes/recipes-summarize-jobs.repository.ts
@@ -15,6 +15,10 @@ import type {
 import { prisma } from "@/src/lib/server/prisma";
 import { inferSourceType } from "@/src/lib/server/recipes/recipes.utils";
 import type { ExtractedRecipeContext } from "@/src/lib/server/recipes/recipes-extraction.service";
+import type {
+  SummarizeJobFailureKind,
+  SummarizeJobStage
+} from "@/src/lib/server/recipes/recipes-summarize-jobs.types";
 
 type SummarizeJobRecord = {
   id: string;
@@ -66,7 +70,8 @@ export async function createSummarizeJob(
       userId,
       sourceUrl,
       sourceType: inferSourceType(sourceUrl),
-      status: "queued"
+      status: "queued",
+      stage: "queued"
     },
     select: {
       id: true,
@@ -122,10 +127,30 @@ export async function markSummarizeJobExtracting(jobId: string) {
     where: { id: jobId },
     data: {
       status: "extracting",
+      stage: "extracting_metadata",
+      attemptCount: { increment: 1 },
+      lastAttemptAt: new Date(),
       errorCode: null,
       errorMessage: null,
+      providerCode: null,
+      providerMessage: null,
+      failureKind: null,
+      mediaDebug: Prisma.JsonNull,
       confidence: null,
       draftPayload: Prisma.JsonNull,
+      updatedAt: new Date()
+    }
+  });
+}
+
+export async function setSummarizeJobStage(
+  jobId: string,
+  stage: SummarizeJobStage
+) {
+  await prisma.summarizeJob.update({
+    where: { id: jobId },
+    data: {
+      stage,
       updatedAt: new Date()
     }
   });
@@ -154,6 +179,7 @@ export async function markSummarizeJobSummarizing(jobId: string) {
     where: { id: jobId },
     data: {
       status: "summarizing",
+      stage: "summarizing",
       updatedAt: new Date()
     }
   });
@@ -168,6 +194,7 @@ export async function completeSummarizeJob(
     where: { id: jobId },
     data: {
       status: "completed",
+      stage: "completed",
       canonicalVideoId: context.canonicalVideoId,
       titleHint: context.title || null,
       descriptionHint: context.description || null,
@@ -182,6 +209,9 @@ export async function completeSummarizeJob(
       } as Prisma.InputJsonValue,
       errorCode: null,
       errorMessage: null,
+      providerCode: null,
+      providerMessage: null,
+      failureKind: null,
       updatedAt: new Date()
     }
   });
@@ -196,6 +226,7 @@ export async function markSummarizeJobInsufficientContext(
     where: { id: jobId },
     data: {
       status: "insufficient_context",
+      stage: "insufficient_context",
       canonicalVideoId: context.canonicalVideoId,
       titleHint: context.title || null,
       descriptionHint: context.description || null,
@@ -206,6 +237,12 @@ export async function markSummarizeJobInsufficientContext(
       draftPayload: Prisma.JsonNull,
       errorCode: "INSUFFICIENT_CONTEXT",
       errorMessage: message,
+      failureKind: context.extractionIssue?.failureKind ?? "insufficient_context",
+      providerCode: context.extractionIssue?.providerCode ?? null,
+      providerMessage: context.extractionIssue?.providerMessage ?? null,
+      mediaDebug: context.extractionIssue?.mediaDebug
+        ? (context.extractionIssue.mediaDebug as Prisma.InputJsonValue)
+        : Prisma.JsonNull,
       updatedAt: new Date()
     }
   });
@@ -214,14 +251,25 @@ export async function markSummarizeJobInsufficientContext(
 export async function markSummarizeJobFailed(
   jobId: string,
   errorCode: string,
-  message: string
+  message: string,
+  options: {
+    failureKind?: SummarizeJobFailureKind;
+    providerCode?: string | null;
+    providerMessage?: string | null;
+    mediaDebug?: Prisma.InputJsonValue | typeof Prisma.JsonNull;
+  } = {}
 ) {
   await prisma.summarizeJob.update({
     where: { id: jobId },
     data: {
       status: "failed",
+      stage: "failed",
       errorCode,
       errorMessage: message,
+      providerCode: options.providerCode ?? null,
+      providerMessage: options.providerMessage ?? null,
+      failureKind: options.failureKind ?? "internal_error",
+      mediaDebug: options.mediaDebug ?? Prisma.JsonNull,
       updatedAt: new Date()
     }
   });

--- a/src/lib/server/recipes/recipes-summarize-jobs.types.ts
+++ b/src/lib/server/recipes/recipes-summarize-jobs.types.ts
@@ -1,0 +1,27 @@
+export const summarizeJobStages = [
+  "queued",
+  "extracting_metadata",
+  "extracting_subtitles",
+  "downloading_media",
+  "transcribing_audio",
+  "extracting_frames",
+  "analyzing_frames",
+  "summarizing",
+  "completed",
+  "insufficient_context",
+  "failed"
+] as const;
+
+export type SummarizeJobStage = (typeof summarizeJobStages)[number];
+
+export const summarizeJobFailureKinds = [
+  "source_rate_limited",
+  "source_unavailable",
+  "media_download_failed",
+  "transcription_failed",
+  "vision_failed",
+  "insufficient_context",
+  "internal_error"
+] as const;
+
+export type SummarizeJobFailureKind = (typeof summarizeJobFailureKinds)[number];

--- a/src/lib/server/recipes/recipes-summarize-queue.service.ts
+++ b/src/lib/server/recipes/recipes-summarize-queue.service.ts
@@ -1,0 +1,22 @@
+import { quickAddJob } from "graphile-worker";
+
+import { getGraphileWorkerUtilsOptions } from "@/src/lib/server/worker/graphile-worker";
+
+export const RECIPES_SUMMARIZE_TASK_IDENTIFIER = "recipes-summarize";
+
+export type RecipesSummarizeTaskPayload = {
+  jobId: string;
+};
+
+export async function enqueueSummarizeJob(jobId: string): Promise<void> {
+  await quickAddJob(
+    getGraphileWorkerUtilsOptions(),
+    RECIPES_SUMMARIZE_TASK_IDENTIFIER,
+    { jobId } satisfies RecipesSummarizeTaskPayload,
+    {
+      jobKey: `recipes-summarize:${jobId}`,
+      jobKeyMode: "unsafe_dedupe",
+      maxAttempts: 1
+    }
+  );
+}

--- a/src/lib/server/recipes/recipes-youtube-audio.service.ts
+++ b/src/lib/server/recipes/recipes-youtube-audio.service.ts
@@ -2,6 +2,8 @@ import { Readable } from "node:stream";
 
 import ytdl from "@distube/ytdl-core";
 
+import type { SummarizeJobFailureKind } from "@/src/lib/server/recipes/recipes-summarize-jobs.types";
+
 const MAX_TRANSCRIPTION_AUDIO_BYTES = 24 * 1024 * 1024;
 const YOUTUBE_REQUEST_HEADERS = {
   "User-Agent": "Mozilla/5.0 (compatible; PantryClip/1.0)",
@@ -15,6 +17,18 @@ export type DownloadedRecipeAudio = {
   fileName: string;
   mimeType: string;
   estimatedBytes: number | null;
+};
+
+export type RecipeAudioDownloadIssue = {
+  failureKind: SummarizeJobFailureKind;
+  providerCode: string;
+  providerMessage: string;
+  mediaDebug?: Record<string, unknown>;
+};
+
+export type DownloadYouTubeRecipeAudioResult = {
+  audio: DownloadedRecipeAudio | null;
+  issue: RecipeAudioDownloadIssue | null;
 };
 
 function parsePositiveInteger(value: string | number | null | undefined): number | null {
@@ -144,9 +158,76 @@ async function readStreamToBuffer(stream: Readable, maxBytes: number): Promise<B
   });
 }
 
+function normalizeErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : "Unknown media download error";
+}
+
+function readStatusCode(error: unknown): number | null {
+  if (!error || typeof error !== "object") {
+    return null;
+  }
+
+  const candidate = error as { statusCode?: unknown; status?: unknown };
+
+  if (typeof candidate.statusCode === "number") {
+    return candidate.statusCode;
+  }
+
+  if (typeof candidate.status === "number") {
+    return candidate.status;
+  }
+
+  return null;
+}
+
+function inferDownloadIssue(
+  canonicalVideoId: string,
+  error: unknown
+): RecipeAudioDownloadIssue {
+  const message = normalizeErrorMessage(error);
+  const statusCode = readStatusCode(error);
+  const lowerMessage = message.toLowerCase();
+  const mediaDebug = {
+    canonicalVideoId,
+    statusCode,
+    errorName: error instanceof Error ? error.name : null
+  } satisfies Record<string, unknown>;
+
+  if (statusCode === 429 || lowerMessage.includes("status code: 429")) {
+    return {
+      failureKind: "source_rate_limited",
+      providerCode: "YOUTUBE_RATE_LIMITED",
+      providerMessage: message,
+      mediaDebug
+    };
+  }
+
+  if (
+    statusCode === 403 ||
+    statusCode === 404 ||
+    statusCode === 410 ||
+    lowerMessage.includes("video unavailable") ||
+    lowerMessage.includes("private video")
+  ) {
+    return {
+      failureKind: "source_unavailable",
+      providerCode: "YOUTUBE_SOURCE_UNAVAILABLE",
+      providerMessage: message,
+      mediaDebug
+    };
+  }
+
+  return {
+    failureKind: "media_download_failed",
+    providerCode: "YOUTUBE_AUDIO_DOWNLOAD_FAILED",
+    providerMessage: message,
+    mediaDebug
+  };
+}
+
 export async function downloadYouTubeRecipeAudio(
   canonicalVideoId: string
-): Promise<DownloadedRecipeAudio | null> {
+): Promise<DownloadYouTubeRecipeAudioResult> {
   try {
     const watchUrl = `https://www.youtube.com/watch?v=${canonicalVideoId}&hl=ko`;
     const info = await ytdl.getInfo(watchUrl, {
@@ -159,13 +240,33 @@ export async function downloadYouTubeRecipeAudio(
     const format = pickPreferredAudioFormat(ytdl.filterFormats(info.formats, "audioonly"));
 
     if (!format) {
-      return null;
+      return {
+        audio: null,
+        issue: {
+          failureKind: "media_download_failed",
+          providerCode: "YOUTUBE_AUDIO_FORMAT_UNAVAILABLE",
+          providerMessage: "No supported YouTube audio format was available.",
+          mediaDebug: { canonicalVideoId }
+        }
+      };
     }
 
     const estimatedBytes = estimateFormatSizeBytes(format);
 
     if (estimatedBytes && estimatedBytes > MAX_TRANSCRIPTION_AUDIO_BYTES) {
-      return null;
+      return {
+        audio: null,
+        issue: {
+          failureKind: "media_download_failed",
+          providerCode: "YOUTUBE_AUDIO_TOO_LARGE",
+          providerMessage: "The selected YouTube audio stream exceeded the transcription size limit.",
+          mediaDebug: {
+            canonicalVideoId,
+            estimatedBytes,
+            maxBytes: MAX_TRANSCRIPTION_AUDIO_BYTES
+          }
+        }
+      };
     }
 
     const buffer = await readStreamToBuffer(
@@ -178,13 +279,19 @@ export async function downloadYouTubeRecipeAudio(
     );
 
     return {
-      buffer,
-      fileName: `short-${canonicalVideoId}.${containerToExtension(format.container)}`,
-      mimeType: format.mimeType?.split(";")[0] ?? containerToMimeType(format.container),
-      estimatedBytes
+      audio: {
+        buffer,
+        fileName: `short-${canonicalVideoId}.${containerToExtension(format.container)}`,
+        mimeType: format.mimeType?.split(";")[0] ?? containerToMimeType(format.container),
+        estimatedBytes
+      },
+      issue: null
     };
   } catch (error) {
     console.error("YouTube audio download failed", error);
-    return null;
+    return {
+      audio: null,
+      issue: inferDownloadIssue(canonicalVideoId, error)
+    };
   }
 }

--- a/src/lib/server/worker/graphile-worker.ts
+++ b/src/lib/server/worker/graphile-worker.ts
@@ -1,0 +1,67 @@
+import type { RunnerOptions, TaskList, WorkerUtilsOptions } from "graphile-worker";
+
+const DEFAULT_GRAPHILE_WORKER_SCHEMA = "graphile_worker";
+const DEFAULT_GRAPHILE_WORKER_CONCURRENCY = 1;
+const DEFAULT_GRAPHILE_WORKER_POLL_INTERVAL_MS = 2_000;
+
+function parsePositiveInteger(value: string | undefined, fallback: number): number {
+  const parsed = Number(value);
+
+  return Number.isFinite(parsed) && parsed > 0 ? Math.floor(parsed) : fallback;
+}
+
+function readQueueConnectionString(): string {
+  const value =
+    process.env.GRAPHILE_WORKER_DATABASE_URL ??
+    process.env.DATABASE_URL;
+
+  if (!value) {
+    throw new Error(
+      "GRAPHILE_WORKER_DATABASE_URL or DATABASE_URL must be set."
+    );
+  }
+
+  return value;
+}
+
+function readRunnerConnectionString(): string {
+  const value =
+    process.env.GRAPHILE_WORKER_DATABASE_URL ??
+    process.env.DIRECT_URL ??
+    process.env.DATABASE_URL;
+
+  if (!value) {
+    throw new Error(
+      "GRAPHILE_WORKER_DATABASE_URL, DIRECT_URL, or DATABASE_URL must be set."
+    );
+  }
+
+  return value;
+}
+
+function getBaseWorkerOptions(connectionString: string): WorkerUtilsOptions {
+  return {
+    connectionString,
+    schema: process.env.GRAPHILE_WORKER_SCHEMA ?? DEFAULT_GRAPHILE_WORKER_SCHEMA,
+    noPreparedStatements: true
+  };
+}
+
+export function getGraphileWorkerUtilsOptions(): WorkerUtilsOptions {
+  return getBaseWorkerOptions(readQueueConnectionString());
+}
+
+export function getGraphileWorkerRunnerOptions(taskList?: TaskList): RunnerOptions {
+  return {
+    ...getBaseWorkerOptions(readRunnerConnectionString()),
+    taskList,
+    concurrency: parsePositiveInteger(
+      process.env.GRAPHILE_WORKER_CONCURRENCY,
+      DEFAULT_GRAPHILE_WORKER_CONCURRENCY
+    ),
+    pollInterval: parsePositiveInteger(
+      process.env.GRAPHILE_WORKER_POLL_INTERVAL_MS,
+      DEFAULT_GRAPHILE_WORKER_POLL_INTERVAL_MS
+    )
+  };
+}

--- a/src/worker/load-env.ts
+++ b/src/worker/load-env.ts
@@ -1,0 +1,72 @@
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+
+const ENV_FILE_ORDER = [".env", ".env.local"] as const;
+
+function parseEnvValue(rawValue: string): string {
+  const trimmed = rawValue.trim();
+
+  if (
+    (trimmed.startsWith("\"") && trimmed.endsWith("\"")) ||
+    (trimmed.startsWith("'") && trimmed.endsWith("'"))
+  ) {
+    return trimmed.slice(1, -1);
+  }
+
+  const commentIndex = trimmed.indexOf(" #");
+  return commentIndex === -1 ? trimmed : trimmed.slice(0, commentIndex).trim();
+}
+
+function parseEnvFile(contents: string): Record<string, string> {
+  const parsed: Record<string, string> = {};
+
+  for (const line of contents.split(/\r?\n/)) {
+    const trimmed = line.trim();
+
+    if (!trimmed || trimmed.startsWith("#")) {
+      continue;
+    }
+
+    const normalized = trimmed.startsWith("export ")
+      ? trimmed.slice("export ".length)
+      : trimmed;
+    const separatorIndex = normalized.indexOf("=");
+
+    if (separatorIndex <= 0) {
+      continue;
+    }
+
+    const key = normalized.slice(0, separatorIndex).trim();
+    const rawValue = normalized.slice(separatorIndex + 1);
+
+    if (!key) {
+      continue;
+    }
+
+    parsed[key] = parseEnvValue(rawValue);
+  }
+
+  return parsed;
+}
+
+export function loadWorkerEnv(cwd: string = process.cwd()): void {
+  const preexistingKeys = new Set(Object.keys(process.env));
+
+  for (const fileName of ENV_FILE_ORDER) {
+    const filePath = path.join(cwd, fileName);
+
+    if (!existsSync(filePath)) {
+      continue;
+    }
+
+    const parsed = parseEnvFile(readFileSync(filePath, "utf8"));
+
+    for (const [key, value] of Object.entries(parsed)) {
+      if (preexistingKeys.has(key)) {
+        continue;
+      }
+
+      process.env[key] = value;
+    }
+  }
+}

--- a/src/worker/migrate.ts
+++ b/src/worker/migrate.ts
@@ -1,0 +1,16 @@
+import { runMigrations } from "graphile-worker";
+
+import { getGraphileWorkerRunnerOptions } from "@/src/lib/server/worker/graphile-worker";
+import { loadWorkerEnv } from "@/src/worker/load-env";
+
+loadWorkerEnv();
+
+async function main() {
+  await runMigrations(getGraphileWorkerRunnerOptions());
+  console.info("Graphile Worker migrations are up to date.");
+}
+
+main().catch((error) => {
+  console.error("Failed to run Graphile Worker migrations", error);
+  process.exit(1);
+});

--- a/src/worker/task-list.ts
+++ b/src/worker/task-list.ts
@@ -1,0 +1,8 @@
+import type { TaskList } from "graphile-worker";
+
+import { RECIPES_SUMMARIZE_TASK_IDENTIFIER } from "@/src/lib/server/recipes/recipes-summarize-queue.service";
+import { recipesSummarizeTask } from "@/src/worker/tasks/recipes-summarize.task";
+
+export const taskList: TaskList = {
+  [RECIPES_SUMMARIZE_TASK_IDENTIFIER]: recipesSummarizeTask
+};

--- a/src/worker/tasks/recipes-summarize.task.ts
+++ b/src/worker/tasks/recipes-summarize.task.ts
@@ -1,0 +1,9 @@
+import type { Task } from "graphile-worker";
+
+import { runSummarizeJob } from "@/src/lib/server/recipes/recipes-summarize-job-runner";
+import type { RecipesSummarizeTaskPayload } from "@/src/lib/server/recipes/recipes-summarize-queue.service";
+
+export const recipesSummarizeTask: Task = async (payload) => {
+  const { jobId } = payload as RecipesSummarizeTaskPayload;
+  await runSummarizeJob(jobId);
+};

--- a/src/worker/worker.ts
+++ b/src/worker/worker.ts
@@ -1,0 +1,23 @@
+import { run, runMigrations } from "graphile-worker";
+
+import { getGraphileWorkerRunnerOptions } from "@/src/lib/server/worker/graphile-worker";
+import { loadWorkerEnv } from "@/src/worker/load-env";
+import { taskList } from "@/src/worker/task-list";
+
+loadWorkerEnv();
+
+async function main() {
+  const options = getGraphileWorkerRunnerOptions(taskList);
+
+  await runMigrations(options);
+
+  const runner = await run(options);
+  console.info("PantryClip worker started.");
+
+  await runner.promise;
+}
+
+main().catch((error) => {
+  console.error("PantryClip worker failed to start", error);
+  process.exit(1);
+});


### PR DESCRIPTION
<!-- pr-description:start -->
## Summary
Move summarize jobs to Graphile Worker and introduce worker-side job diagnostics. Adds new worker infrastructure, routes, and Prisma migrations to support asynchronous summarize job processing and monitoring.

## Changes
- Introduce Graphile Worker integration and related worker entrypoint
- Add worker utilities and task definitions:
  - src/worker/graphile-worker.ts
  - src/worker/load-env.ts
  - src/worker/migrate.ts
  - src/worker/task-list.ts
  - src/worker/worker.ts
  - src/worker/tasks/recipes-summarize.task.ts
- Implement summarize-related server changes:
  - src/lib/server/recipes/recipes-summarize-queue.service.ts (new)
  - src/lib/server/recipes/recipes-summarize-jobs.repository.ts (modified)
  - src/lib/server/recipes/recipes-summarize-jobs.types.ts (new)
  - src/lib/server/recipes/recipes-summarize-job-runner.ts (modified)
  - src/app/api/recipes/summarize/route.ts (modified)
  - src/lib/server/recipes/recipes-extraction.service.ts (modified)
- Prisma and DB schema updates:
  - prisma/schema.prisma (modified)
  - prisma/migrations/20260330195000_add_summarize_job_stage_fields/migration.sql (added)
- Documentation and planning artifacts added:
  - docs/* (multiple new docs)
  - PLAN.md (added)
  - pantryclip-api-design-v1.0.md (added)
  - pantryclip-domain-schema-v1.0.md (added)
  - pantryclip-build-plan-v1.0.md (added)
  - pantryclip-prd-v1.0.md (added)
  - etc.
- Misc:
  - .gitignore adjustments
  - README.md updates
  - package.json and pnpm-lock.yaml updated

## Risks
- None identified.

## Testing
- No explicit tests included in this diff; ensure local run of worker migration and startup sequences aligns with new Graphile Worker integration.
<!-- pr-description:end -->