### PR TITLE
Add URL-only recipe saves with best-effort titles and editable empty-state support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,6 @@ Thumbs.db
 
 AGENTS.md
 .agents
+
+
+*-player-script.js

--- a/src/apis/@types/recipes.ts
+++ b/src/apis/@types/recipes.ts
@@ -31,6 +31,11 @@ export type SummarizeRecipeRequest = {
   sourceUrl: string;
 };
 
+export type SaveRecipeUrlRequest = {
+  sourceUrl: string;
+  title?: string;
+};
+
 export type SummarizeJobStatus =
   | "queued"
   | "extracting"

--- a/src/apis/recipes.ts
+++ b/src/apis/recipes.ts
@@ -5,6 +5,7 @@ import type {
   ListRecipesRequest,
   ListRecipesResponse,
   RecipeDto,
+  SaveRecipeUrlRequest,
   SummarizeJobHandleResponse,
   SummarizeJobResultResponse,
   SummarizeRecipeRequest,
@@ -61,6 +62,20 @@ export async function getSummarizeJob(jobId: string) {
   }
 
   return (await response.json()) as SummarizeJobResultResponse;
+}
+
+export async function saveRecipeUrl(payload: SaveRecipeUrlRequest) {
+  const response = await fetch("/api/recipes/save-url", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(payload)
+  });
+
+  if (!response.ok) {
+    throw new Error(await toErrorMessage(response, "Failed to save recipe URL."));
+  }
+
+  return (await response.json()) as RecipeDto;
 }
 
 export async function createRecipe(payload: CreateRecipeRequest) {

--- a/src/app/api/recipes/save-url/route.ts
+++ b/src/app/api/recipes/save-url/route.ts
@@ -1,0 +1,20 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { saveRecipeUrlSchema } from "@/src/apps/recipes/recipes.schemas";
+import { requireUserId } from "@/src/lib/auth/require-user-id";
+import { saveRecipeFromUrl } from "@/src/lib/server/recipes/recipes-save-url.service";
+import { toErrorResponse } from "@/src/lib/utils/api-error";
+
+export async function POST(request: NextRequest) {
+  try {
+    const userId = await requireUserId();
+    const json = await request.json();
+    const input = saveRecipeUrlSchema.parse(json);
+    const created = await saveRecipeFromUrl(userId, input);
+
+    return NextResponse.json(created, { status: 201 });
+  } catch (error) {
+    const normalized = toErrorResponse(error);
+    return NextResponse.json(normalized.body, { status: normalized.status });
+  }
+}

--- a/src/apps/recipes/recipes-home.container.tsx
+++ b/src/apps/recipes/recipes-home.container.tsx
@@ -9,6 +9,7 @@ import {
   deleteRecipe as deleteRecipeRequest,
   getSummarizeJob as getSummarizeJobRequest,
   listRecipes as listRecipesRequest,
+  saveRecipeUrl as saveRecipeUrlRequest,
   toggleSaveRecipe as toggleSaveRecipeRequest,
   updateRecipe as updateRecipeRequest
 } from "@/src/apis/recipes";
@@ -455,6 +456,7 @@ export function RecipesHomeContainer() {
   const [urlError, setUrlError]               = useState("");
   const [recipesError, setRecipesError]       = useState("");
   const [isGenerating, setIsGenerating]       = useState(false);
+  const [isSavingUrlOnly, setIsSavingUrlOnly] = useState(false);
   const [summarizeJobStatus, setSummarizeJobStatus] = useState<SummarizeJobStatus | null>(null);
   const [draftErrors, setDraftErrors]         = useState<Partial<Record<keyof RecipeDraft, string>>>({});
   const [toastMessage, setToastMessage]       = useState("");
@@ -601,6 +603,32 @@ export function RecipesHomeContainer() {
       setUrlError(err instanceof Error ? err.message : "AI 초안 생성에 실패했습니다.");
       openManualDraft(sourceUrl);
     } finally { setIsGenerating(false); setSummarizeJobStatus(null); }
+  };
+
+  const handleSaveUrlOnly = async () => {
+    const sourceUrl = addUrl.trim();
+    if (!sourceUrl) { setUrlError("URL을 입력해주세요."); return; }
+    if (!/^https?:\/\//i.test(sourceUrl)) { setUrlError("http:// 또는 https://로 시작하는 URL을 입력해주세요."); return; }
+
+    setUrlError("");
+    setIsSavingUrlOnly(true);
+
+    try {
+      const created = await saveRecipeUrlRequest({
+        sourceUrl,
+        title: draft.sourceUrl.trim() === sourceUrl ? draft.title.trim() || undefined : undefined
+      });
+      const next = toRecipe(created);
+      setRecipes((c) => [next, ...c]);
+      setSelectedRecipeId(next.id);
+      resetDraft();
+      setScreen("detail");
+      showToast("링크가 저장되었습니다. 세부 내용은 나중에 수정할 수 있어요.");
+    } catch (err) {
+      setUrlError(err instanceof Error ? err.message : "URL 저장에 실패했습니다.");
+    } finally {
+      setIsSavingUrlOnly(false);
+    }
   };
 
   // Save AI draft directly from inline review card
@@ -982,10 +1010,21 @@ export function RecipesHomeContainer() {
                     type="button"
                     className="mt-3 h-12 w-full gap-2.5 rounded-xl text-[15px] font-bold"
                     onClick={() => void handleGenerate()}
-                    disabled={isGenerating}
+                    disabled={isGenerating || isSavingUrlOnly}
                   >
                     <IcBolt className="h-[18px] w-[18px]" />
                     {isGenerating ? toSummarizeStatusLabel(summarizeJobStatus) : "Generate with AI"}
+                  </Button>
+
+                  <Button
+                    type="button"
+                    variant="outline"
+                    className="mt-3 h-12 w-full gap-2.5 rounded-xl text-[15px] font-bold"
+                    onClick={() => void handleSaveUrlOnly()}
+                    disabled={isGenerating || isSavingUrlOnly}
+                  >
+                    <IcBookmark className="h-[18px] w-[18px]" />
+                    {isSavingUrlOnly ? "Saving URL..." : "Save URL Only"}
                   </Button>
 
                   {/* Skeleton loading state */}
@@ -1247,28 +1286,40 @@ export function RecipesHomeContainer() {
                 {/* Ingredients */}
                 <div className="mt-6">
                   <Label>Ingredients</Label>
-                  <div className="mt-3 space-y-1.5">
-                    {toIngredientItems(selectedRecipe.ingredientsText).map((item) => (
-                      <div key={item} className="flex items-center justify-between rounded-xl bg-card px-4 py-3">
-                        <span className="text-sm">{item}</span>
-                      </div>
-                    ))}
-                  </div>
+                  {toIngredientItems(selectedRecipe.ingredientsText).length > 0 ? (
+                    <div className="mt-3 space-y-1.5">
+                      {toIngredientItems(selectedRecipe.ingredientsText).map((item) => (
+                        <div key={item} className="flex items-center justify-between rounded-xl bg-card px-4 py-3">
+                          <span className="text-sm">{item}</span>
+                        </div>
+                      ))}
+                    </div>
+                  ) : (
+                    <div className="mt-3 rounded-xl bg-card px-4 py-4 text-sm text-muted-foreground">
+                      아직 재료가 없습니다. Edit에서 나중에 추가할 수 있어요.
+                    </div>
+                  )}
                 </div>
 
                 {/* Preparation */}
                 <div className="mt-6">
                   <Label>Preparation</Label>
-                  <div className="mt-3 space-y-2">
-                    {toStepItems(selectedRecipe.stepsText).map((step, i) => (
-                      <div key={step} className="flex gap-4 rounded-xl bg-card px-4 py-3.5">
-                        <div className="flex h-7 w-7 flex-shrink-0 items-center justify-center rounded-full bg-primary text-[11px] font-bold text-primary-foreground">
-                          {String(i + 1).padStart(2, "0")}
+                  {toStepItems(selectedRecipe.stepsText).length > 0 ? (
+                    <div className="mt-3 space-y-2">
+                      {toStepItems(selectedRecipe.stepsText).map((step, i) => (
+                        <div key={step} className="flex gap-4 rounded-xl bg-card px-4 py-3.5">
+                          <div className="flex h-7 w-7 flex-shrink-0 items-center justify-center rounded-full bg-primary text-[11px] font-bold text-primary-foreground">
+                            {String(i + 1).padStart(2, "0")}
+                          </div>
+                          <p className="flex-1 text-sm leading-relaxed">{step}</p>
                         </div>
-                        <p className="flex-1 text-sm leading-relaxed">{step}</p>
-                      </div>
-                    ))}
-                  </div>
+                      ))}
+                    </div>
+                  ) : (
+                    <div className="mt-3 rounded-xl bg-card px-4 py-4 text-sm text-muted-foreground">
+                      아직 조리 과정이 없습니다. 링크를 먼저 저장하고 나중에 정리해도 됩니다.
+                    </div>
+                  )}
                 </div>
 
                 {/* Edit / Delete */}

--- a/src/apps/recipes/recipes.schemas.ts
+++ b/src/apps/recipes/recipes.schemas.ts
@@ -27,6 +27,11 @@ export const createRecipeSchema = z.object({
   aiConfidence: z.number().min(0).max(1).nullable().optional()
 });
 
+export const saveRecipeUrlSchema = z.object({
+  sourceUrl: z.string().url(),
+  title: z.string().trim().max(140).optional()
+});
+
 export const summarizeRecipeSchema = z.object({
   sourceUrl: z.string().url()
 });

--- a/src/apps/recipes/recipes.types.ts
+++ b/src/apps/recipes/recipes.types.ts
@@ -3,6 +3,7 @@ import type { z } from "zod";
 import {
   createRecipeSchema,
   listRecipesQuerySchema,
+  saveRecipeUrlSchema,
   sourceTypeSchema,
   summarizeDraftResultSchema,
   summarizeJobHandleSchema,
@@ -17,6 +18,7 @@ export type SourceType = z.infer<typeof sourceTypeSchema>;
 export type SummarySource = z.infer<typeof summarySourceSchema>;
 
 export type CreateRecipeInput = z.infer<typeof createRecipeSchema>;
+export type SaveRecipeUrlInput = z.infer<typeof saveRecipeUrlSchema>;
 export type UpdateRecipeInput = z.infer<typeof updateRecipeSchema>;
 export type SummarizeRecipeInput = z.infer<typeof summarizeRecipeSchema>;
 export type SummarizeJobStatus = z.infer<typeof summarizeJobStatusSchema>;

--- a/src/lib/server/openapi/openapi.spec.ts
+++ b/src/lib/server/openapi/openapi.spec.ts
@@ -4,6 +4,7 @@ import { z } from "zod";
 import {
   createRecipeSchema,
   listRecipesQuerySchema,
+  saveRecipeUrlSchema,
   sourceTypeSchema,
   summarizeJobHandleSchema,
   summarizeJobResultSchema,
@@ -49,10 +50,11 @@ const recipeSchema = registry.register(
     sourceUrl: z.string().url(),
     sourceType: sourceTypeOpenApiSchema,
     title: z.string().min(1).max(140),
-    ingredientsText: z.string().min(1),
-    stepsText: z.string().min(1),
+    ingredientsText: z.string(),
+    stepsText: z.string(),
     summarySource: summarySourceOpenApiSchema,
     aiConfidence: z.number().min(0).max(1).nullable(),
+    isSaved: z.boolean(),
     createdAt: z.string().datetime(),
     updatedAt: z.string().datetime()
   })
@@ -68,6 +70,7 @@ const summarizeJobResultOpenApiSchema = summarizeJobResultSchema.openapi(
 );
 
 const createRecipeRequestSchema = createRecipeSchema.openapi("CreateRecipeRequest");
+const saveRecipeUrlRequestSchema = saveRecipeUrlSchema.openapi("SaveRecipeUrlRequest");
 const updateRecipeRequestSchema = updateRecipeSchema.openapi("UpdateRecipeRequest", {
   description: "At least one field must be provided.",
   minProperties: 1
@@ -162,6 +165,49 @@ registry.registerPath({
       content: {
         "application/json": {
           schema: summarizeJobHandleOpenApiSchema
+        }
+      }
+    },
+    400: {
+      description: "Validation error",
+      content: {
+        "application/json": {
+          schema: errorResponseSchema
+        }
+      }
+    },
+    401: {
+      description: "Unauthorized",
+      content: {
+        "application/json": {
+          schema: errorResponseSchema
+        }
+      }
+    }
+  }
+});
+
+registry.registerPath({
+  method: "post",
+  path: "/api/recipes/save-url",
+  tags: ["Recipes"],
+  summary: "Save a recipe link with a best-effort title and empty details",
+  request: {
+    body: {
+      required: true,
+      content: {
+        "application/json": {
+          schema: saveRecipeUrlRequestSchema
+        }
+      }
+    }
+  },
+  responses: {
+    201: {
+      description: "URL saved as a recipe",
+      content: {
+        "application/json": {
+          schema: recipeSchema
         }
       }
     },

--- a/src/lib/server/recipes/recipes-extraction.service.ts
+++ b/src/lib/server/recipes/recipes-extraction.service.ts
@@ -40,6 +40,7 @@ export type ExtractedRecipeContext = {
 
 type ExtractRecipeContextOptions = {
   onStageChange?: (stage: SummarizeJobStage) => Promise<void> | void;
+  enableAudioTranscription?: boolean;
 };
 
 export type RecipeExtractionIssue = {
@@ -244,7 +245,11 @@ async function maybeTranscribeYouTubeAudio(
   transcriptText: string;
   extractionIssue: RecipeExtractionIssue | null;
 }> {
-  if (!context.canonicalVideoId || context.subtitleText.length >= MIN_RECIPE_NARRATIVE_LENGTH) {
+  if (
+    !context.canonicalVideoId ||
+    context.subtitleText.length >= MIN_RECIPE_NARRATIVE_LENGTH ||
+    options.enableAudioTranscription === false
+  ) {
     return {
       transcriptText: "",
       extractionIssue: null

--- a/src/lib/server/recipes/recipes-save-url.service.ts
+++ b/src/lib/server/recipes/recipes-save-url.service.ts
@@ -1,0 +1,56 @@
+import type { SaveRecipeUrlInput, SourceType } from "@/src/apps/recipes/recipes.types";
+import { createRecipeUrlOnly } from "@/src/lib/server/recipes/recipes.repository";
+import { inferSourceType } from "@/src/lib/server/recipes/recipes.utils";
+import { extractRecipeContext } from "@/src/lib/server/recipes/recipes-extraction.service";
+
+function buildFallbackTitle(sourceType: SourceType, sourceUrl: string): string {
+  try {
+    const hostname = new URL(sourceUrl).hostname.replace(/^www\./, "");
+
+    if (sourceType === "youtube_shorts") {
+      return "Saved YouTube Shorts";
+    }
+
+    if (sourceType === "instagram_reels") {
+      return "Saved Instagram Reel";
+    }
+
+    return `Saved from ${hostname}`;
+  } catch {
+    return "Saved recipe link";
+  }
+}
+
+function normalizeSavedTitle(
+  preferredTitle: string | undefined,
+  extractedTitle: string,
+  sourceType: SourceType,
+  sourceUrl: string
+): string {
+  const title = preferredTitle?.trim() || extractedTitle.trim();
+
+  if (title) {
+    return title.slice(0, 140);
+  }
+
+  return buildFallbackTitle(sourceType, sourceUrl);
+}
+
+export async function saveRecipeFromUrl(
+  userId: string,
+  input: SaveRecipeUrlInput
+) {
+  const sourceUrl = input.sourceUrl.trim();
+  const sourceType = inferSourceType(sourceUrl);
+  const extracted = await extractRecipeContext(
+    { sourceUrl },
+    { enableAudioTranscription: false }
+  );
+  const title = normalizeSavedTitle(input.title, extracted.title, sourceType, sourceUrl);
+
+  return createRecipeUrlOnly(userId, {
+    sourceUrl,
+    sourceType,
+    title
+  });
+}

--- a/src/lib/server/recipes/recipes.repository.ts
+++ b/src/lib/server/recipes/recipes.repository.ts
@@ -5,6 +5,7 @@ import type {
   ListRecipesQuery,
   PaginatedRecipes,
   Recipe,
+  SourceType,
   UpdateRecipeInput
 } from "@/src/apps/recipes/recipes.types";
 import { prisma } from "@/src/lib/server/prisma";
@@ -51,6 +52,30 @@ export async function createRecipe(userId: string, input: CreateRecipeInput): Pr
       stepsText: input.stepsText.trim(),
       summarySource: input.summarySource,
       aiConfidence: input.aiConfidence ?? null
+    }
+  });
+
+  return toRecipe(recipe);
+}
+
+export async function createRecipeUrlOnly(
+  userId: string,
+  input: {
+    sourceUrl: string;
+    sourceType: SourceType;
+    title: string;
+  }
+): Promise<Recipe> {
+  const recipe = await prisma.recipe.create({
+    data: {
+      userId,
+      sourceUrl: input.sourceUrl.trim(),
+      sourceType: input.sourceType,
+      title: input.title.trim(),
+      ingredientsText: "",
+      stepsText: "",
+      summarySource: "manual",
+      aiConfidence: null
     }
   });
 


### PR DESCRIPTION
<!-- pr-description:start -->
## Summary
Adds URL-only recipe saving with best-effort titles and empty-state friendly support. Introduces a new API endpoint to save a recipe from a URL, updates client and types to handle URL-only saves, and integrates empty-detail handling for saved URLs.

## Changes
- .gitignore: adjusted to ignore extra patterns
- src/apis/@types/recipes.ts: added SaveRecipeUrlRequest type
- src/apis/recipes.ts: added saveRecipeUrl function
- src/app/api/recipes/save-url/route.ts: added API route handler for saving URL-based recipes
- src/apps/recipes/recipes-home.container.tsx: added client-side handleSaveUrlOnly workflow and state
- src/apps/recipes/recipes.schemas.ts: added saveRecipeUrlSchema
- src/apps/recipes/recipes.types.ts: added SaveRecipeUrlInput type
- src/lib/server/openapi/openapi.spec.ts: exposed save-url schema in OpenAPI
- src/lib/server/recipes/recipes-extraction.service.ts: extended context options to support future toggles (enableAudioTranscription)
- src/lib/server/recipes/recipes-save-url.service.ts: new service to save a URL as a Recipe with best-effort title and fallback naming
- src/lib/server/recipes/recipes.repository.ts: new createRecipeUrlOnly function to persist URL-only recipes

## Risks
- None identified.

## Testing
- No explicit tests included in this patch. Please run integration tests for API route, client save-url flow, and repository persistence to verify behavior.
<!-- pr-description:end -->