### PR TITLE
Add confirm password field to sign up form

### DIFF
--- a/src/apps/recipes/recipes-home.container.tsx
+++ b/src/apps/recipes/recipes-home.container.tsx
@@ -246,6 +246,8 @@ const copy = {
       signUpDescription: "짧은 요리 영상을 나만의 레시피로 저장해보세요.",
       email: "이메일",
       password: "비밀번호",
+      confirmPassword: "비밀번호 확인",
+      passwordMismatch: "비밀번호가 일치하지 않습니다.",
       forgotPassword: "비밀번호 찾기",
       loading: "로딩 중...",
       login: "로그인",
@@ -440,6 +442,8 @@ const copy = {
       signUpDescription: "Save short cooking videos as your own recipes.",
       email: "Email",
       password: "Password",
+      confirmPassword: "Confirm Password",
+      passwordMismatch: "Passwords do not match.",
       forgotPassword: "Forgot Password?",
       loading: "Loading...",
       login: "Login",
@@ -1317,8 +1321,10 @@ export function RecipesHomeContainer() {
   const [showCollectionsModal, setShowCollectionsModal] = useState(false);
   const [authEmail, setAuthEmail] = useState("");
   const [authPassword, setAuthPassword] = useState("");
+  const [authConfirmPassword, setAuthConfirmPassword] = useState("");
   const [authError, setAuthError] = useState("");
   const [authNotice, setAuthNotice] = useState("");
+  const [authConfirmPasswordError, setAuthConfirmPasswordError] = useState("");
   const [authMode, setAuthMode] = useState<"sign_in" | "sign_up">("sign_in");
   const [authBusy, setAuthBusy] = useState(false);
   const [showPassword, setShowPassword] = useState(false);
@@ -1932,12 +1938,20 @@ export function RecipesHomeContainer() {
   const handleAuthSubmit = async () => {
     setAuthError("");
     setAuthNotice("");
+    setAuthConfirmPasswordError("");
+
+    if (authMode === "sign_up" && authPassword !== authConfirmPassword) {
+      setAuthConfirmPasswordError(ui.auth.passwordMismatch);
+      return;
+    }
+
     setAuthBusy(true);
     try {
       if (authMode === "sign_up") {
         await signUpWithPassword(authEmail.trim(), authPassword);
         setAuthNotice(ui.auth.signUpNotice);
         setAuthPassword("");
+        setAuthConfirmPassword("");
         return;
       }
       await signInWithPassword(authEmail.trim(), authPassword);
@@ -2288,7 +2302,12 @@ export function RecipesHomeContainer() {
                     <Input
                       type={showPassword ? "text" : "password"}
                       value={authPassword}
-                      onChange={(e) => setAuthPassword(e.target.value)}
+                      onChange={(e) => {
+                        setAuthPassword(e.target.value);
+                        if (authConfirmPasswordError) {
+                          setAuthConfirmPasswordError("");
+                        }
+                      }}
                       className="h-[52px] rounded-xl border border-border/70 bg-card pl-11 pr-11 text-sm focus-visible:ring-1 focus-visible:ring-primary"
                     />
                     <button
@@ -2304,6 +2323,45 @@ export function RecipesHomeContainer() {
                     </button>
                   </div>
                 </div>
+
+                {authMode === "sign_up" && (
+                  <div className="space-y-2">
+                    <Label>{ui.auth.confirmPassword}</Label>
+                    <div className="relative">
+                      <div className="pointer-events-none absolute inset-y-0 left-4 flex items-center">
+                        <IcLock className="h-[18px] w-[18px] text-muted-foreground" />
+                      </div>
+                      <Input
+                        type={showPassword ? "text" : "password"}
+                        value={authConfirmPassword}
+                        onChange={(e) => {
+                          setAuthConfirmPassword(e.target.value);
+                          if (authConfirmPasswordError) {
+                            setAuthConfirmPasswordError("");
+                          }
+                        }}
+                        aria-invalid={authConfirmPasswordError ? "true" : "false"}
+                        className="h-[52px] rounded-xl border border-border/70 bg-card pl-11 pr-11 text-sm focus-visible:ring-1 focus-visible:ring-primary"
+                      />
+                      <button
+                        type="button"
+                        onClick={() => setShowPassword((v) => !v)}
+                        className="absolute inset-y-0 right-4 flex items-center text-muted-foreground"
+                      >
+                        {showPassword ? (
+                          <IcEyeOff className="h-[18px] w-[18px]" />
+                        ) : (
+                          <IcEye className="h-[18px] w-[18px]" />
+                        )}
+                      </button>
+                    </div>
+                    {authConfirmPasswordError && (
+                      <p className="text-xs text-destructive">
+                        {authConfirmPasswordError}
+                      </p>
+                    )}
+                  </div>
+                )}
 
                 {authError && (
                   <p className="text-sm text-destructive">{authError}</p>
@@ -2344,8 +2402,10 @@ export function RecipesHomeContainer() {
                       setAuthMode((m) =>
                         m === "sign_in" ? "sign_up" : "sign_in"
                       );
+                      setAuthConfirmPassword("");
                       setAuthError("");
                       setAuthNotice("");
+                      setAuthConfirmPasswordError("");
                     }}
                   >
                     {authMode === "sign_in"


### PR DESCRIPTION
<!-- pr-description:start -->
## Summary
Add confirm password field to the sign-up form with validation and localized strings for both Korean and English. Ensures password confirmation is checked during sign-up and clears fields on successful sign-up.

## Changes
- Add confirmPassword and passwordMismatch UI strings in both Korean and English copies.
- Introduce authConfirmPassword state and authConfirmPasswordError state.
- Validate password confirmation on sign-up submission; show password mismatch error if not matching.
- Clear confirm password field after successful sign-up.
- Wire up onChange handling for confirm password with relevant validation flow.

## Risks
- None identified.

## Testing
- Validate UI shows "비밀번호 확인" / "Confirm Password" label.
- Ensure sign-up with mismatched passwords shows "비밀번호가 일치하지 않습니다." / "Passwords do not match."
- Ensure sign-up completes and clears confirm password field on success.
<!-- pr-description:end -->