### PR TITLE
docs(readme): reposition README as product landing page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,65 @@
 # PantryClip
 
-PantryClip is a mobile-first Next.js app for turning short-form cooking videos into editable recipe drafts.
+PantryClip turns short-form cooking videos into structured, editable recipe notes.
 
-## Current stack
+Shorts and Reels are easy to save, but hard to actually cook from later. PantryClip is built for that gap: paste a video link, turn it into a readable recipe draft, edit what matters, and keep it in a searchable personal recipe library.
+
+## Why PantryClip
+
+- Save recipe ideas from short-form video without losing the details
+- Convert video content into cooking-friendly notes with title, ingredients, and steps
+- Review and edit the draft before saving, instead of trusting AI blindly
+- Reopen recipes later in a format that is much easier to use in the kitchen
+
+## Product Snapshot
+
+PantryClip is currently a mobile-first web app focused on a single core workflow:
+
+1. Paste a recipe video URL
+2. Generate an editable recipe draft
+3. Review or rewrite the content as needed
+4. Save it to your personal library
+5. Search and revisit it later
+
+Current product highlights:
+
+- Mobile-first recipe workflow
+- Email/password authentication
+- AI-assisted draft generation
+- Manual editing before final save
+- Personal recipe library with search
+- Recipe detail, update, and delete flows
+
+Current scope notes:
+
+- AI drafting is currently tuned for YouTube Shorts
+- PantryClip is intentionally focused on short-form recipe organization
+- Pantry, meal planning, shopping lists, and social features are out of scope for the MVP
+
+## What Makes It Useful
+
+PantryClip is not trying to be a general recipe platform. It is a focused tool for people who already discover recipes through short-form video and want a cleaner way to save and reuse them.
+
+That means the product is optimized for:
+
+- fast capture
+- minimal typing
+- readable cooking notes
+- easy search and revisit
+
+## Visuals And Marketing Assets
+
+The repo does not include polished product screenshots yet. A placeholder structure for future README visuals lives in [`docs/assets/readme/README.md`](./docs/assets/readme/README.md).
+
+Recommended future assets:
+
+- auth screen screenshot
+- add-recipe flow screenshot
+- recipe library screenshot
+- recipe detail screenshot
+- short GIF showing URL to draft flow
+
+## Tech Stack
 
 - Next.js App Router
 - React 19 + TypeScript
@@ -12,7 +69,7 @@ PantryClip is a mobile-first Next.js app for turning short-form cooking videos i
 - OpenAI-backed summarize pipeline
 - Graphile Worker for background summarize jobs
 
-## Project structure
+## Architecture At A Glance
 
 - `src/app/`: thin pages, layouts, and route handlers
 - `src/apps/`: feature modules and app-level providers
@@ -21,10 +78,10 @@ PantryClip is a mobile-first Next.js app for turning short-form cooking videos i
 - `src/lib/auth/`: Supabase auth helpers
 - `src/lib/server/`: server-only repositories, services, and worker helpers
 - `src/worker/`: background worker entrypoints and task registration
-- `prisma/`: schema and SQL migrations
+- `prisma/`: schema and migrations
 - `docs/`: product and implementation notes
 
-## Quick start
+## Quick Start
 
 Install dependencies and generate Prisma types:
 
@@ -32,57 +89,50 @@ Install dependencies and generate Prisma types:
 pnpm install
 ```
 
-Start the web app:
+Start the app:
 
 ```bash
 pnpm dev
 ```
 
-Open [http://localhost:3000](http://localhost:3000).
+Then open [http://localhost:3000](http://localhost:3000).
 
-## Background worker
+## Environment
 
-Summarize jobs are asynchronous. To run them locally:
+Recommended local environment variables:
 
-1. Start the app with `pnpm dev`
-2. Run Graphile Worker migrations:
-
-```bash
-pnpm worker:migrate
-```
-
-3. Start the worker in a second terminal:
-
-```bash
-pnpm worker
-```
-
-Recommended environment setup:
-
-- `DATABASE_URL`: app database connection string
-- `GRAPHILE_WORKER_DATABASE_URL`: optional dedicated worker connection string
+- `DATABASE_URL`
+- `GRAPHILE_WORKER_DATABASE_URL` for a dedicated worker connection
 - `OPENAI_API_KEY`
 - `NEXT_PUBLIC_SUPABASE_URL`
 - `NEXT_PUBLIC_SUPABASE_ANON_KEY`
 
-When the web app runs on Vercel and the worker runs elsewhere, keep the app on its normal runtime DB URL and point the dedicated worker at its own connection string.
+## Background Worker
 
-## API docs
+PantryClip uses asynchronous summarize jobs for AI recipe drafting.
 
-After starting the app, open:
+Run the full local flow:
+
+1. Start the app with `pnpm dev`
+2. Run worker migrations with `pnpm worker:migrate`
+3. Start the worker in a second terminal with `pnpm worker`
+
+When the app runs on Vercel and the worker runs elsewhere, keep the app on its runtime database URL and point the worker to its own connection string.
+
+## API Docs
+
+After the app is running:
 
 - [http://localhost:3000/api-docs](http://localhost:3000/api-docs) for Swagger UI
 - [http://localhost:3000/api/openapi](http://localhost:3000/api/openapi) for raw OpenAPI JSON
 
-## Current behavior
+## Current Behavior
 
-- Supabase email/password auth is live
-- Recipes are persisted with Prisma/Postgres
+- Authenticated users can create and manage their own recipes
+- Recipe data is stored with Prisma and PostgreSQL
 - `POST /api/recipes/summarize` creates an async summarize job and returns `202`
-- The client polls job status and either:
-  - fills an AI-generated draft
-  - or opens manual entry if extraction is weak or generation fails
-- AI drafting is currently positioned for YouTube Shorts only
+- The client polls summarize job status before opening the draft review step
+- Users can continue manually if AI extraction is weak or draft generation fails
 
 ## Verification
 
@@ -93,3 +143,11 @@ pnpm prisma:generate
 pnpm typecheck
 pnpm lint
 ```
+
+## Product Docs
+
+For deeper product and implementation context, start with:
+
+- [`docs/pantryclip-project-brief-v0.1.md`](./docs/pantryclip-project-brief-v0.1.md)
+- [`docs/pantryclip-prd-v1.0.md`](./docs/pantryclip-prd-v1.0.md)
+- [`docs/pantryclip-feature-list-v1.0.md`](./docs/pantryclip-feature-list-v1.0.md)

--- a/docs/assets/readme/README.md
+++ b/docs/assets/readme/README.md
@@ -1,0 +1,18 @@
+# README Asset Placeholders
+
+This directory is reserved for screenshots and lightweight marketing assets used by the top-level `README.md`.
+
+Suggested filenames:
+
+- `auth-screen.png`
+- `add-recipe-flow.png`
+- `recipe-library.png`
+- `recipe-detail.png`
+- `url-to-draft.gif`
+
+Guidelines:
+
+- Prefer mobile-sized screenshots that match PantryClip's product framing
+- Keep assets compressed enough for GitHub rendering
+- Use descriptive filenames so the README stays easy to maintain
+- Update `README.md` references when assets are added


### PR DESCRIPTION
<!-- pr-description:start -->
## Summary
Reposition README to serve as a product landing page highlighting PantryClip’s core workflow, value proposition, and future visuals. Added a dedicated assets placeholder section under docs/assets/readme/README.md to host marketing visuals.

## Changes
- README.md updated to reflect a product-focused narrative:
  - Revised opening description
  - Added sections: Why PantryClip, Product Snapshot, Current scope notes, What Makes It Useful, Visuals And Marketing Assets, Tech Stack
  - Expanded highlights of core workflow and scope
- docs/assets/readme/README.md added as a placeholder for future marketing assets and guidance

## Risks
- None identified.

## Testing
- No tests indicated by the changes.
<!-- pr-description:end -->