### PR TITLE
Handle duplicate-email signup attempts correctly

### DIFF
--- a/src/apps/app/auth.provider.tsx
+++ b/src/apps/app/auth.provider.tsx
@@ -1,20 +1,37 @@
 "use client";
 
-import type { Session } from "@supabase/supabase-js";
+import type { Session, User } from "@supabase/supabase-js";
 import { createContext, type ReactNode, useContext, useEffect, useMemo, useState } from "react";
 
 import { getSupabaseBrowserClient } from "@/src/lib/auth/supabase-client";
+
+type SignUpResult = "created" | "already_registered";
 
 type AuthContextValue = {
   isReady: boolean;
   session: Session | null;
   userEmail: string | null;
   signInWithPassword: (email: string, password: string) => Promise<void>;
-  signUpWithPassword: (email: string, password: string) => Promise<void>;
+  signUpWithPassword: (email: string, password: string) => Promise<SignUpResult>;
   signOut: () => Promise<void>;
 };
 
 const AuthContext = createContext<AuthContextValue | null>(null);
+
+function isObfuscatedDuplicateSignUp(user: User | null, session: Session | null) {
+  if (!user || session) {
+    return false;
+  }
+
+  const hasEmailIdentity = user.identities?.some(
+    (identity) => identity.provider === "email"
+  );
+  const hasEmailProvider = user.app_metadata?.provider === "email";
+
+  // Supabase can return an obfuscated user object for existing confirmed accounts
+  // instead of throwing "User already registered", depending on Auth settings.
+  return !hasEmailIdentity && !hasEmailProvider;
+}
 
 export function AuthProvider({ children }: { children: ReactNode }) {
   const [isReady, setIsReady] = useState(false);
@@ -71,11 +88,21 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       },
       async signUpWithPassword(email: string, password: string) {
         const supabase = getSupabaseBrowserClient();
-        const { error } = await supabase.auth.signUp({ email, password });
+        const { data, error } = await supabase.auth.signUp({ email, password });
 
         if (error) {
+          if (error.message.toLowerCase().includes("already registered")) {
+            return "already_registered";
+          }
+
           throw error;
         }
+
+        if (isObfuscatedDuplicateSignUp(data.user, data.session)) {
+          return "already_registered";
+        }
+
+        return "created";
       },
       async signOut() {
         const supabase = getSupabaseBrowserClient();

--- a/src/apps/recipes/recipes-home.container.tsx
+++ b/src/apps/recipes/recipes-home.container.tsx
@@ -258,6 +258,8 @@ const copy = {
       signInSwitch: "로그인",
       signUpNotice:
         "계정이 생성되었습니다. 이메일을 확인하여 인증을 완료해주세요.",
+      emailAlreadyRegistered:
+        "이 이메일로 가입된 계정이 이미 있습니다. 로그인으로 계속해주세요.",
       authFailed: "인증에 실패했습니다."
     },
     library: {
@@ -452,6 +454,8 @@ const copy = {
       signInSwitch: "Sign In",
       signUpNotice:
         "Your account was created. Please check your email to confirm it.",
+      emailAlreadyRegistered:
+        "An account already exists for this email. Please continue by signing in.",
       authFailed: "Authentication failed."
     },
     library: {
@@ -1935,7 +1939,14 @@ export function RecipesHomeContainer() {
     setAuthBusy(true);
     try {
       if (authMode === "sign_up") {
-        await signUpWithPassword(authEmail.trim(), authPassword);
+        const result = await signUpWithPassword(authEmail.trim(), authPassword);
+
+        if (result === "already_registered") {
+          setAuthMode("sign_in");
+          setAuthError(ui.auth.emailAlreadyRegistered);
+          return;
+        }
+
         setAuthNotice(ui.auth.signUpNotice);
         setAuthPassword("");
         return;


### PR DESCRIPTION
<!-- pr-description:start -->
## Summary
Implements correct handling of duplicate email signup attempts by distinguishing obfuscated duplicate accounts and returning a consistent feedback flow. Updates UI copy to inform users when an email is already registered and redirects to sign-in flow accordingly.

## Changes
- src/apps/app/auth.provider.tsx
  - Extend user type import to include User.
  - Add isObfuscatedDuplicateSignUp helper to detect potential duplicate sign-ups when Supabase returns an obfuscated user.
  - signUpWithPassword now:
    - Uses data from signUp response and handles error messages containing "already registered".
    - Uses isObfuscatedDuplicateSignUp to treat certain cases as already_registered.
    - Returns "created" or "already_registered" accordingly.
- src/apps/recipes/recipes-home.container.tsx
  - Add UI copy for emailAlreadyRegistered in multiple locales.
  - Update flow in sign-up path to redirect to sign-in with proper feedback when duplicate email is detected.

## Risks
- None identified.

## Testing
- None identified.
<!-- pr-description:end -->