### PR TITLE
Detect obfuscated duplicate signup responses

### DIFF
--- a/src/apps/app/auth.provider.tsx
+++ b/src/apps/app/auth.provider.tsx
@@ -23,14 +23,11 @@ function isObfuscatedDuplicateSignUp(user: User | null, session: Session | null)
     return false;
   }
 
-  const hasEmailIdentity = user.identities?.some(
-    (identity) => identity.provider === "email"
-  );
-  const hasEmailProvider = user.app_metadata?.provider === "email";
-
   // Supabase can return an obfuscated user object for existing confirmed accounts
   // instead of throwing "User already registered", depending on Auth settings.
-  return !hasEmailIdentity && !hasEmailProvider;
+  // In practice, the documented workaround is that the returned user has no
+  // linked identities in that duplicate-account path.
+  return (user.identities?.length ?? 0) === 0;
 }
 
 export function AuthProvider({ children }: { children: ReactNode }) {


### PR DESCRIPTION
<!-- pr-description:start -->
## Summary
Fix handling of obfuscated duplicate signup responses by relying on the absence of linked identities rather than email provider checks.

## Changes
- Simplify isObfuscatedDuplicateSignUp to rely on user.identities length
- Remove checks for email identity and email provider in duplicate signup logic

## Risks
- None identified.

## Testing
- None described in diff.
<!-- pr-description:end -->