### PR TITLE
Simplify language picker to K/E switch

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@distube/ytdl-core": "^4.16.12",
     "@prisma/client": "^6.5.0",
     "@radix-ui/react-checkbox": "^1.3.3",
+    "@radix-ui/react-switch": "^1.2.6",
     "@radix-ui/react-toggle-group": "^1.1.11",
     "@supabase/ssr": "^0.7.0",
     "@supabase/supabase-js": "^2.49.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       '@radix-ui/react-checkbox':
         specifier: ^1.3.3
         version: 1.3.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-switch':
+        specifier: ^1.2.6
+        version: 1.2.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@radix-ui/react-toggle-group':
         specifier: ^1.1.11
         version: 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -771,6 +774,19 @@ packages:
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
       '@types/react':
+        optional: true
+
+  '@radix-ui/react-switch@1.2.6':
+    resolution: {integrity: sha512-bByzr1+ep1zk4VubeEVViV592vu2lHE2BZY5OnzehZqOOgogN80+mNtCqPkhn2gklJqOpxWgPoYTSnhBCqpOXQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
         optional: true
 
   '@radix-ui/react-toggle-group@1.1.11':
@@ -3381,6 +3397,21 @@ snapshots:
       react: 19.2.4
     optionalDependencies:
       '@types/react': 19.2.14
+
+  '@radix-ui/react-switch@1.2.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-previous': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-size': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
   '@radix-ui/react-toggle-group@1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:

--- a/src/apps/recipes/recipes-home.container.tsx
+++ b/src/apps/recipes/recipes-home.container.tsx
@@ -29,7 +29,7 @@ import { Button } from "@/src/components/ui/button";
 import { Checkbox } from "@/src/components/ui/checkbox";
 import { Input } from "@/src/components/ui/input";
 import { Skeleton } from "@/src/components/ui/skeleton";
-import { ToggleGroup, ToggleGroupItem } from "@/src/components/ui/toggle-group";
+import { Switch } from "@/src/components/ui/switch";
 
 // ─── Types ──────────────────────────────────────────────────────────────────
 
@@ -1402,12 +1402,6 @@ export function RecipesHomeContainer() {
     savedCollectionRecipes.length === 0 &&
     collections.length > 0;
 
-  const handleLanguageChange = (value: string) => {
-    if (value === "ko" || value === "en") {
-      setLanguage(value);
-    }
-  };
-
   const matchesSavedCollectionFilter = (recipe: Recipe) => {
     if (selectedSavedCollectionId === ALL_SAVED_COLLECTION_ID) {
       return recipe.isSaved;
@@ -2266,23 +2260,16 @@ export function RecipesHomeContainer() {
           {/* ══════════════════════════ AUTH ══════════════════════════ */}
           {screen === "auth" && (
             <div className="flex min-h-screen flex-col justify-center px-7 py-12">
-              <div className="mb-8 flex items-center justify-end gap-3">
-                <span className="text-[11px] font-bold uppercase tracking-[0.12em] text-muted-foreground">
-                  {ui.auth.languageLabel}
-                </span>
-                <ToggleGroup
+              <div className="mb-8 flex justify-end">
+                <Switch
                   aria-label={ui.auth.languageLabel}
-                  type="single"
-                  value={language}
-                  onValueChange={handleLanguageChange}
+                  checked={language === "en"}
+                  onCheckedChange={(checked) =>
+                    setLanguage(checked ? "en" : "ko")
+                  }
                 >
-                  <ToggleGroupItem value="ko">
-                    {ui.auth.languageKorean}
-                  </ToggleGroupItem>
-                  <ToggleGroupItem value="en">
-                    {ui.auth.languageEnglish}
-                  </ToggleGroupItem>
-                </ToggleGroup>
+                  {language === "en" ? "E" : "K"}
+                </Switch>
               </div>
 
               {/* Logo + heading */}

--- a/src/components/ui/switch.tsx
+++ b/src/components/ui/switch.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import * as SwitchPrimitive from "@radix-ui/react-switch";
+import * as React from "react";
+
+import { cn } from "@/src/lib/utils";
+
+type SwitchProps = React.ComponentPropsWithoutRef<typeof SwitchPrimitive.Root> & {
+  thumbClassName?: string;
+};
+
+const Switch = React.forwardRef<
+  React.ElementRef<typeof SwitchPrimitive.Root>,
+  SwitchProps
+>(({ className, thumbClassName, children, ...props }, ref) => (
+  <SwitchPrimitive.Root
+    ref={ref}
+    className={cn(
+      "peer inline-flex h-7 w-12 shrink-0 cursor-pointer items-center rounded-full border border-border/70 bg-card p-0.5 shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50",
+      className
+    )}
+    {...props}
+  >
+    <SwitchPrimitive.Thumb
+      className={cn(
+        "pointer-events-none flex size-6 items-center justify-center rounded-full bg-background text-[11px] font-bold text-foreground shadow transition-transform data-[state=checked]:translate-x-5 data-[state=unchecked]:translate-x-0",
+        thumbClassName
+      )}
+    >
+      {children}
+    </SwitchPrimitive.Thumb>
+  </SwitchPrimitive.Root>
+));
+
+Switch.displayName = SwitchPrimitive.Root.displayName;
+
+export { Switch };


### PR DESCRIPTION
<!-- pr-description:start -->
## Summary
Simplify language picker by replacing a language toggle group with a single on/off switch (K/E) in the auth section. Introduces a new reusable Switch component and integrates it into the RecipesHomeContainer.

## Changes
- Add new dependency: @radix-ui/react-switch (in package.json)
- Add new Switch UI component: src/components/ui/switch.tsx
- Update recipes-home container to use the new Switch for language selection in auth view
- Remove previous ToggleGroup usage for language selection
- Minor adjustments to layout to accommodate the new switch (align to end)

## Risks
- None identified.

## Testing
- Manual verification of the auth section shows a single switch labeled by current language state (K/E) and updates language accordingly. Ensure styling aligns with app theme.
<!-- pr-description:end -->