### PR TITLE
[codex] Prevent iOS input zoom in mobile form fields

### DIFF
--- a/src/apps/recipes/recipes-home.container.tsx
+++ b/src/apps/recipes/recipes-home.container.tsx
@@ -987,7 +987,7 @@ function IngredientListEditor({
         <div key={i} className="flex items-center gap-2">
           <span className="text-sm font-bold text-primary">–</span>
           <input
-            className="h-10 flex-1 rounded-lg border border-border/70 bg-card px-3 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-primary"
+            className="h-10 flex-1 rounded-lg border border-border/70 bg-card px-3 text-base text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-primary md:text-sm"
             value={item}
             placeholder={replaceCount(editorCopy.ingredientPlaceholder, i + 1)}
             onChange={(e) => {
@@ -1057,7 +1057,7 @@ function StepListEditor({
             {i + 1}
           </span>
           <textarea
-            className="min-h-[60px] flex-1 resize-none rounded-lg border border-border/70 bg-card px-3 py-2.5 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-primary"
+            className="min-h-[60px] flex-1 resize-none rounded-lg border border-border/70 bg-card px-3 py-2.5 text-base text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-primary md:text-sm"
             value={step}
             placeholder={replaceCount(editorCopy.stepPlaceholder, i + 1)}
             rows={2}
@@ -2485,7 +2485,7 @@ export function RecipesHomeContainer() {
                       placeholder="example@email.com"
                       value={authEmail}
                       onChange={(e) => setAuthEmail(e.target.value)}
-                      className="h-[52px] rounded-xl border border-border/70 bg-card pl-11 text-sm focus-visible:ring-1 focus-visible:ring-primary"
+                      className="h-[52px] rounded-xl border border-border/70 bg-card pl-11 text-base focus-visible:ring-1 focus-visible:ring-primary md:text-sm"
                     />
                   </div>
                 </div>
@@ -2516,7 +2516,7 @@ export function RecipesHomeContainer() {
                           setAuthConfirmPasswordError("");
                         }
                       }}
-                      className="h-[52px] rounded-xl border border-border/70 bg-card pl-11 pr-11 text-sm focus-visible:ring-1 focus-visible:ring-primary"
+                      className="h-[52px] rounded-xl border border-border/70 bg-card pl-11 pr-11 text-base focus-visible:ring-1 focus-visible:ring-primary md:text-sm"
                     />
                     <button
                       type="button"
@@ -2551,7 +2551,7 @@ export function RecipesHomeContainer() {
                         aria-invalid={
                           authConfirmPasswordError ? "true" : "false"
                         }
-                        className="h-[52px] rounded-xl border border-border/70 bg-card pl-11 pr-11 text-sm focus-visible:ring-1 focus-visible:ring-primary"
+                        className="h-[52px] rounded-xl border border-border/70 bg-card pl-11 pr-11 text-base focus-visible:ring-1 focus-visible:ring-primary md:text-sm"
                       />
                       <button
                         type="button"
@@ -2664,7 +2664,7 @@ export function RecipesHomeContainer() {
                     placeholder={ui.library.searchPlaceholder}
                     value={searchQuery}
                     onChange={(e) => setSearchQuery(e.target.value)}
-                    className="h-12 rounded-xl border border-border/70 bg-card pl-10 text-sm focus-visible:ring-1 focus-visible:ring-primary"
+                    className="h-12 rounded-xl border border-border/70 bg-card pl-10 text-base focus-visible:ring-1 focus-visible:ring-primary md:text-sm"
                   />
                 </div>
 
@@ -2902,7 +2902,7 @@ export function RecipesHomeContainer() {
                 <div className="mt-6">
                   <div className="relative">
                     <Input
-                      className="h-12 rounded-xl border border-border/70 bg-card pr-12 text-sm focus-visible:ring-1 focus-visible:ring-primary"
+                      className="h-12 rounded-xl border border-border/70 bg-card pr-12 text-base focus-visible:ring-1 focus-visible:ring-primary md:text-sm"
                       placeholder="https://youtube.com/shorts/..."
                       value={addUrl}
                       onChange={(e) => setAddUrl(e.target.value)}
@@ -2978,7 +2978,7 @@ export function RecipesHomeContainer() {
                       <div className="space-y-2">
                         <Label>{ui.add.titleLabel}</Label>
                         <input
-                          className="h-12 w-full rounded-xl border border-border/70 bg-card px-4 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-primary"
+                          className="h-12 w-full rounded-xl border border-border/70 bg-card px-4 text-base text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-primary md:text-sm"
                           value={draft.title}
                           onChange={(e) =>
                             setDraft((c) => ({ ...c, title: e.target.value }))

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -8,7 +8,7 @@ const Input = React.forwardRef<HTMLInputElement, React.ComponentProps<"input">>(
       <input
         type={type}
         className={cn(
-          "flex h-10 w-full rounded-xl border border-input bg-background px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50",
+          "flex h-10 w-full rounded-xl border border-input bg-background px-3 py-2 text-base ring-offset-background file:border-0 file:bg-transparent file:text-base file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 md:text-sm md:file:text-sm",
           className
         )}
         ref={ref}

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -7,7 +7,7 @@ const Textarea = React.forwardRef<HTMLTextAreaElement, React.ComponentProps<"tex
     return (
       <textarea
         className={cn(
-          "flex min-h-[80px] w-full rounded-xl border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50",
+          "flex min-h-[80px] w-full rounded-xl border border-input bg-background px-3 py-2 text-base ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
           className
         )}
         ref={ref}


### PR DESCRIPTION
<!-- pr-description:start -->
## Summary
Fixes to prevent iOS input zoom on mobile forms by adjusting font sizes and responsive typography across inputs and textareas. Updates ensure consistent base text sizing to avoid automatic zoom when focusing form fields.

## Changes
- Adjust input and textarea font sizes to base/text-base with responsive md:text-sm variants
- Update classNames in:
  - src/apps/recipes/recipes-home.container.tsx (several input/textarea elements)
  - src/components/ui/input.tsx
  - src/components/ui/textarea.tsx

## Risks
- Minor layout shifts due to font-size changes on various form controls; should be visually minor and consistent with existing design system.

## Testing
- None identified.
<!-- pr-description:end -->

## What changed
- update shared `Input` and `Textarea` primitives to use `text-base` on mobile and fall back to `text-sm` from `md` upward
- update the few inline recipe form fields that were still hard-coded to `text-sm`
- keep the existing desktop visual density while preventing iOS Safari focus zoom on mobile

## Why
iOS Safari automatically zooms focused form controls when their font size is below 16px. Several PantryClip form fields rendered at `text-sm` (14px), which caused the page to zoom slightly when users tapped into an input on mobile.

## Impact
- mobile users can focus text fields without the viewport zooming in
- desktop styling remains effectively unchanged

## Validation
- `npx eslint src/components/ui/input.tsx src/components/ui/textarea.tsx src/apps/recipes/recipes-home.container.tsx`
- repo-wide `npm run lint` still reports existing unrelated errors from generated `*-player-script.js` files in the repository root