### PR TITLE
Handle user upsert email conflicts

### DIFF
--- a/src/lib/auth/require-user-id.ts
+++ b/src/lib/auth/require-user-id.ts
@@ -1,3 +1,5 @@
+import { Prisma } from "@prisma/client";
+
 import { getSupabaseServerClient } from "@/src/lib/auth/supabase-server";
 import { prisma } from "@/src/lib/server/prisma";
 import { ApiError } from "@/src/lib/utils/api-error";
@@ -13,16 +15,34 @@ export async function requireUserId(): Promise<string> {
     throw new ApiError("UNAUTHORIZED", "Authentication required", 401);
   }
 
-  await prisma.user.upsert({
-    where: { id: user.id },
-    update: {
-      email: user.email ?? `${user.id}@users.pantryclip.local`
-    },
-    create: {
-      id: user.id,
-      email: user.email ?? `${user.id}@users.pantryclip.local`
+  const email = user.email ?? `${user.id}@users.pantryclip.local`;
+
+  try {
+    await prisma.user.upsert({
+      where: { id: user.id },
+      update: { email },
+      create: {
+        id: user.id,
+        email
+      }
+    });
+  } catch (upsertError) {
+    if (
+      upsertError instanceof Prisma.PrismaClientKnownRequestError &&
+      upsertError.code === "P2002"
+    ) {
+      const existingUser = await prisma.user.findUnique({
+        where: { email },
+        select: { id: true }
+      });
+
+      if (existingUser) {
+        return existingUser.id;
+      }
     }
-  });
+
+    throw upsertError;
+  }
 
   return user.id;
 }


### PR DESCRIPTION
<!-- pr-description:start -->
## Summary
Handle conflicts when upserting a user by email during authentication. If a user with the same email already exists, reuse that user's ID instead of failing, ensuring consistent user identification.

## Changes
- Update requireUserId to derive email and perform upsert with proper handling.
- On P2002 (unique constraint) error, lookup existing user by email and return its id.
- Fall back to throwing the original error if no existing user is found.

## Risks
- None identified.

## Testing
- Ensure that when a user with a new email is upserted, the user is created correctly.
- Ensure that when a conflict on email occurs, the existing user ID is returned and no crash happens.
- Ensure other authentication paths remain unaffected.
<!-- pr-description:end -->