### PR TITLE
Adding Supabase signup template

### DIFF
--- a/docs/supabase/signup-confirmation-email.html
+++ b/docs/supabase/signup-confirmation-email.html
@@ -1,0 +1,202 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Confirm your PantryClip account</title>
+  </head>
+  <body
+    style="
+      margin: 0;
+      padding: 0;
+      background-color: #111111;
+      font-family: Outfit, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      color: #f5f5f5;
+    "
+  >
+    <div
+      style="
+        display: none;
+        max-height: 0;
+        overflow: hidden;
+        opacity: 0;
+        mso-hide: all;
+      "
+    >
+      Confirm your email to start saving short-form recipe videos as clean,
+      searchable cooking notes in PantryClip.
+    </div>
+
+    <table
+      role="presentation"
+      width="100%"
+      cellspacing="0"
+      cellpadding="0"
+      style="background-color: #111111"
+    >
+      <tr>
+        <td align="center" style="padding: 32px 16px">
+          <table
+            role="presentation"
+            width="100%"
+            cellspacing="0"
+            cellpadding="0"
+            style="max-width: 560px"
+          >
+            <tr>
+              <td style="padding-bottom: 16px; color: #e1965d; font-size: 24px; font-weight: 700">
+                PantryClip
+              </td>
+            </tr>
+            <tr>
+              <td
+                style="
+                  border: 1px solid #2b2b2b;
+                  border-radius: 28px;
+                  background:
+                    radial-gradient(circle at top left, rgba(225, 150, 93, 0.18), transparent 42%),
+                    linear-gradient(180deg, #1a1a1a, #171717);
+                  padding: 32px 28px;
+                  box-shadow: 0 24px 80px -44px rgba(225, 150, 93, 0.55);
+                "
+              >
+                <div
+                  style="
+                    display: inline-block;
+                    margin-bottom: 16px;
+                    border: 1px solid rgba(255, 255, 255, 0.1);
+                    border-radius: 999px;
+                    padding: 8px 12px;
+                    color: #d0d0d0;
+                    font-size: 12px;
+                    font-weight: 700;
+                    letter-spacing: 0.08em;
+                    text-transform: uppercase;
+                  "
+                >
+                  Confirm Your Account
+                </div>
+
+                <h1
+                  style="
+                    margin: 0 0 12px;
+                    color: #ffffff;
+                    font-size: 32px;
+                    line-height: 1.1;
+                    font-weight: 800;
+                  "
+                >
+                  Save recipes you’ll actually use later.
+                </h1>
+
+                <p
+                  style="
+                    margin: 0 0 24px;
+                    color: #c6c6c6;
+                    font-size: 16px;
+                    line-height: 1.6;
+                  "
+                >
+                  You received this email because someone used
+                  <strong>{{ .Email }}</strong> to create a PantryClip account.
+                  Confirm your email to start turning recipe Shorts and Reels into
+                  structured cooking notes.
+                </p>
+
+                <table role="presentation" cellspacing="0" cellpadding="0" style="margin-bottom: 24px">
+                  <tr>
+                    <td
+                      align="center"
+                      style="
+                        border-radius: 16px;
+                        background-color: #e1965d;
+                      "
+                    >
+                      <a
+                        href="{{ .ConfirmationURL }}"
+                        style="
+                          display: inline-block;
+                          padding: 14px 24px;
+                          color: #171717;
+                          text-decoration: none;
+                          font-size: 16px;
+                          font-weight: 800;
+                        "
+                      >
+                        Confirm Email
+                      </a>
+                    </td>
+                  </tr>
+                </table>
+
+                <div
+                  style="
+                    border: 1px solid rgba(255, 255, 255, 0.08);
+                    border-radius: 20px;
+                    background-color: rgba(0, 0, 0, 0.22);
+                    padding: 18px 18px 6px;
+                    margin-bottom: 24px;
+                  "
+                >
+                  <p
+                    style="
+                      margin: 0 0 12px;
+                      color: #ffffff;
+                      font-size: 14px;
+                      line-height: 1.5;
+                      font-weight: 700;
+                    "
+                  >
+                    What happens next
+                  </p>
+                  <p style="margin: 0 0 12px; color: #c6c6c6; font-size: 14px; line-height: 1.6">
+                    1. Confirm your email address
+                  </p>
+                  <p style="margin: 0 0 12px; color: #c6c6c6; font-size: 14px; line-height: 1.6">
+                    2. Paste a Shorts or Reels recipe link
+                  </p>
+                  <p style="margin: 0 0 12px; color: #c6c6c6; font-size: 14px; line-height: 1.6">
+                    3. Clean up the draft and save it to your recipe library
+                  </p>
+                </div>
+
+                <p
+                  style="
+                    margin: 0 0 10px;
+                    color: #d0d0d0;
+                    font-size: 13px;
+                    line-height: 1.6;
+                  "
+                >
+                  If the button does not work, copy and paste this link into your browser:
+                </p>
+                <p
+                  style="
+                    margin: 0 0 24px;
+                    word-break: break-all;
+                    color: #e1965d;
+                    font-size: 13px;
+                    line-height: 1.7;
+                  "
+                >
+                  {{ .ConfirmationURL }}
+                </p>
+
+                <p
+                  style="
+                    margin: 0;
+                    color: #909090;
+                    font-size: 12px;
+                    line-height: 1.6;
+                  "
+                >
+                  If you did not sign up for PantryClip, you can safely ignore this email.
+                </p>
+              </td>
+            </tr>
+          </table>
+        </td>
+      </tr>
+    </table>
+  </body>
+</html>

--- a/docs/supabase/signup-confirmation-email.md
+++ b/docs/supabase/signup-confirmation-email.md
@@ -1,0 +1,35 @@
+# Supabase Sign-Up Confirmation Email
+
+This repo stores the PantryClip sign-up confirmation email as a dashboard-ready HTML template:
+
+- HTML template: [`docs/supabase/signup-confirmation-email.html`](./signup-confirmation-email.html)
+
+## Recommended Supabase Settings
+
+- Subject line: `Confirm your PantryClip account`
+- Preheader text:
+  `Confirm your email to start saving short-form recipe videos as clean, searchable cooking notes in PantryClip.`
+
+## Supabase Template Variables Used
+
+- `{{ .Email }}` shows the recipient email for reassurance
+- `{{ .ConfirmationURL }}` powers the primary button and fallback link
+
+The template intentionally relies on `{{ .ConfirmationURL }}` so it remains compatible with the existing PantryClip sign-up flow.
+
+## How To Apply It
+
+1. Open Supabase Dashboard.
+2. Go to `Authentication` -> `Email Templates`.
+3. Select the sign-up confirmation template.
+4. Set the subject line above.
+5. Paste the HTML from [`docs/supabase/signup-confirmation-email.html`](./signup-confirmation-email.html).
+6. Save and send a test email.
+
+## Verification Checklist
+
+- The email explains why it was sent.
+- The `Confirm Email` button is prominent on mobile and desktop.
+- The fallback URL is visible and usable.
+- Clicking the CTA still follows Supabase's confirmation link behavior.
+- The email feels branded and trustworthy instead of generic.


### PR DESCRIPTION
<!-- pr-description:start -->
## Summary
Add a Supabase sign-up confirmation email template, including an HTML email template and a short Markdown guide describing its use and configuration.

## Changes
- Added docs/supabase/signup-confirmation-email.html (HTML email template)
- Added docs/supabase/signup-confirmation-email.md (README-style guide for the template)

## Risks
- None identified.

## Testing
- Not applicable for this diff; no automated tests indicated.
<!-- pr-description:end -->